### PR TITLE
feat(scripts): guard uninstall when service is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ Remove the installed binary and wasm artifacts (default prefix `~/.cargo`):
 ```bash
 ./scripts/uninstall.sh
 ```
+
+If the service is running, stop and uninstall in one step:
+
+```bash
+./scripts/uninstall.sh --stop
+```

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -5,11 +5,48 @@ PREFIX="${PREFIX:-$HOME/.cargo}"
 BIN_DIR="${BIN_DIR:-$PREFIX/bin}"
 WASM_DIR="${WASM_DIR:-$PREFIX/share/simpleclaw/wasm}"
 BIN_PATH="${BIN_DIR}/simpleclaw"
+PID_PATH="${HOME}/.simpleclaw/run/service.pid"
+STOP_FIRST=0
+
+if [[ "${1:-}" == "--stop" ]]; then
+  STOP_FIRST=1
+elif [[ $# -gt 0 ]]; then
+  echo "Usage: $0 [--stop]"
+  exit 2
+fi
 
 echo "Uninstalling SimpleClaw"
 echo "  prefix: ${PREFIX}"
 echo "  binary: ${BIN_PATH}"
 echo "  wasm dir: ${WASM_DIR}"
+echo "  pid path: ${PID_PATH}"
+
+if [[ -f "${PID_PATH}" ]]; then
+  pid="$(tr -d '[:space:]' < "${PID_PATH}")"
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    if [[ ${STOP_FIRST} -eq 1 ]]; then
+      if [[ -x "${BIN_PATH}" ]]; then
+        "${BIN_PATH}" system stop
+      elif command -v simpleclaw >/dev/null 2>&1; then
+        simpleclaw system stop
+      else
+        echo "Service is running (pid ${pid}), but no simpleclaw binary is available to stop it."
+        echo "Stop it manually, then retry uninstall."
+        exit 1
+      fi
+      sleep 1
+      if kill -0 "${pid}" 2>/dev/null; then
+        echo "Service is still running (pid ${pid}). Uninstall aborted."
+        echo "Run 'simpleclaw system stop' and retry."
+        exit 1
+      fi
+    else
+      echo "Service is running (pid ${pid}). Uninstall aborted."
+      echo "Run 'simpleclaw system stop' first, or rerun with '--stop'."
+      exit 1
+    fi
+  fi
+fi
 
 if [[ -f "${BIN_PATH}" ]]; then
   rm -f "${BIN_PATH}"


### PR DESCRIPTION
## Summary
- add a running-service guard to scripts/uninstall.sh
- abort uninstall when a live PID is detected
- add optional --stop flag to stop service before uninstall
- document the new uninstall behavior in README

## Testing
- bash -n scripts/uninstall.sh