### PR TITLE
feat(gateway): add configurable streaming output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3922,6 +3922,7 @@ dependencies = [
  "sqlite-vec",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -4360,6 +4361,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.37",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "process"] }
+tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 scraper = "0.22"
 url = "2"
 deadpool-sqlite = "0.9"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -94,7 +94,8 @@ impl AgentRuntime {
             self,
             inbound,
             memory_session_id,
-            context
+            context,
+            on_text_delta
         ),
         fields(
             trace_id = %inbound.trace_id,
@@ -107,6 +108,7 @@ impl AgentRuntime {
         inbound: &InboundMessage,
         memory_session_id: &str,
         context: &RuntimeContext,
+        on_text_delta: Option<Arc<dyn Fn(&str) + Send + Sync>>,
     ) -> Result<RunOutcome, FrameworkError> {
         let execution_started = Instant::now();
         info!(status = "started", "agent execution");
@@ -166,6 +168,7 @@ impl AgentRuntime {
                 is_dm: inbound.is_dm,
             }),
             source_message_id: inbound.source_message_id.clone(),
+            on_text_delta,
         };
 
         let mut outcome = match context.react_loop.run(params, history).await {
@@ -413,8 +416,8 @@ mod tests {
     use crate::channels::InboundMessage;
     use crate::channels::{Channel, ChannelInbound};
     use crate::config::{
-        AgentInnerConfig, ExecutionDefaultsConfig, GatewayChannelKind, MemoryRecallConfig,
-        RoutingConfig,
+        AgentInnerConfig, ChannelOutputMode, ExecutionDefaultsConfig, GatewayChannelKind,
+        MemoryRecallConfig, RoutingConfig,
     };
     use crate::error::FrameworkError;
     use crate::gateway::Gateway;
@@ -425,7 +428,9 @@ mod tests {
     use crate::providers::{Message, Provider, ProviderFactory, ProviderResponse, ToolDefinition};
     use crate::react::ReactLoop;
     use crate::tools::skill::SkillFactory;
-    use crate::tools::{AgentInvokeRequest, AgentInvoker, InvokeOutcome, ProcessManager, default_factory};
+    use crate::tools::{
+        AgentInvokeRequest, AgentInvoker, InvokeOutcome, ProcessManager, default_factory,
+    };
 
     use super::{
         AgentDirectory, AgentRuntime, AgentRuntimeConfig, RuntimeContext, ToolRuntime,
@@ -697,14 +702,21 @@ mod tests {
     fn test_gateway() -> Arc<Gateway> {
         let mut channels: HashMap<GatewayChannelKind, Arc<dyn Channel>> = HashMap::new();
         channels.insert(GatewayChannelKind::Discord, Arc::new(QuietChannel));
-        Arc::new(Gateway::new(channels, RoutingConfig::default()))
+        Arc::new(Gateway::new(
+            channels,
+            HashMap::from([(GatewayChannelKind::Discord, ChannelOutputMode::Streaming)]),
+            RoutingConfig::default(),
+        ))
     }
 
     fn test_react_loop(provider: Arc<dyn Provider>) -> Arc<ReactLoop> {
         Arc::new(ReactLoop::new(
             ProviderFactory::from_parts(HashMap::from([(
                 "default".to_owned(),
-                (Box::new(ForwardProvider { inner: provider }) as Box<dyn Provider>, true),
+                (
+                    Box::new(ForwardProvider { inner: provider }) as Box<dyn Provider>,
+                    true,
+                ),
             )])),
             default_factory(),
             SkillFactory::new(PathBuf::from("/tmp/simpleclaw-skill-test")),
@@ -813,7 +825,12 @@ mod tests {
         let runtime = AgentRuntime::new(test_runtime_config());
 
         let outcome = runtime
-            .run(&test_inbound(false, Some("guild-789")), "sess-1", &context)
+            .run(
+                &test_inbound(false, Some("guild-789")),
+                "sess-1",
+                &context,
+                None,
+            )
             .await
             .expect("runtime should succeed");
 
@@ -862,7 +879,7 @@ mod tests {
         let runtime = AgentRuntime::new(config);
 
         let outcome = runtime
-            .run(&test_inbound(false, None), "sess-2", &context)
+            .run(&test_inbound(false, None), "sess-2", &context, None)
             .await
             .expect("runtime should succeed");
 

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use serenity::builder::EditMessage;
 use serenity::http::Http;
 use serenity::model::channel::Message as DiscordMessage;
 use serenity::model::channel::MessageReaction;
@@ -112,6 +113,10 @@ impl EventHandler for DiscordHandler {
 
 #[async_trait]
 impl Channel for DiscordChannel {
+    fn supports_message_editing(&self) -> bool {
+        true
+    }
+
     async fn send_message(&self, channel_id: &str, content: &str) -> Result<(), FrameworkError> {
         let channel_id = parse_channel_id(channel_id)?;
         tracing::debug!(status = "sending", "discord send");
@@ -120,6 +125,36 @@ impl Channel for DiscordChannel {
             .await
             .map_err(|e| FrameworkError::Config(format!("discord send failed: {e}")))?;
         tracing::debug!(status = "completed", "discord send");
+        Ok(())
+    }
+
+    async fn send_message_with_id(
+        &self,
+        channel_id: &str,
+        content: &str,
+    ) -> Result<Option<String>, FrameworkError> {
+        let channel_id = parse_channel_id(channel_id)?;
+        tracing::debug!(status = "sending", "discord send");
+        let message = channel_id
+            .say(&self.http, content)
+            .await
+            .map_err(|e| FrameworkError::Config(format!("discord send failed: {e}")))?;
+        tracing::debug!(status = "completed", message_id = %message.id.get(), "discord send");
+        Ok(Some(message.id.get().to_string()))
+    }
+
+    async fn edit_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        content: &str,
+    ) -> Result<(), FrameworkError> {
+        let channel_id = parse_channel_id(channel_id)?;
+        let message_id = parse_message_id(message_id)?;
+        channel_id
+            .edit_message(&self.http, message_id, EditMessage::new().content(content))
+            .await
+            .map_err(|e| FrameworkError::Config(format!("discord edit failed: {e}")))?;
         Ok(())
     }
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -11,7 +11,29 @@ pub use types::{ChannelInbound, InboundMessage};
 
 #[async_trait]
 pub trait Channel: Send + Sync {
+    fn supports_message_editing(&self) -> bool {
+        false
+    }
+
     async fn send_message(&self, channel_id: &str, content: &str) -> Result<(), FrameworkError>;
+    async fn send_message_with_id(
+        &self,
+        channel_id: &str,
+        content: &str,
+    ) -> Result<Option<String>, FrameworkError> {
+        self.send_message(channel_id, content).await?;
+        Ok(None)
+    }
+    async fn edit_message(
+        &self,
+        _channel_id: &str,
+        _message_id: &str,
+        _content: &str,
+    ) -> Result<(), FrameworkError> {
+        Err(FrameworkError::Tool(
+            "channel does not support editing messages".to_owned(),
+        ))
+    }
     async fn add_reaction(
         &self,
         channel_id: &str,

--- a/src/config/gateway.rs
+++ b/src/config/gateway.rs
@@ -34,10 +34,25 @@ impl GatewayChannelKind {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelOutputMode {
+    Streaming,
+    Normal,
+}
+
+impl Default for ChannelOutputMode {
+    fn default() -> Self {
+        Self::Streaming
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ChannelConfig {
     pub enabled: bool,
+    #[serde(default)]
+    pub output: ChannelOutputMode,
     #[serde(default)]
     pub token: Option<String>,
 }
@@ -46,6 +61,7 @@ impl Default for ChannelConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            output: ChannelOutputMode::Streaming,
             token: None,
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,7 +29,7 @@ pub use execution::ExecutionDefaultsConfig;
 pub use execution::{AgentExecutionOverrides, MemoryRecallOverrides};
 #[allow(unused_imports)]
 pub use execution::{ExecutionConfig, LogLevel, MemoryRecallConfig, TransparencyConfig};
-pub use gateway::{ChannelConfig, GatewayChannelKind, GatewayConfig};
+pub use gateway::{ChannelConfig, ChannelOutputMode, GatewayChannelKind, GatewayConfig};
 pub use providers::{GeminiProviderConfig, ProviderEntryConfig, ProviderKind, ProvidersConfig};
 #[allow(unused_imports)]
 pub use routing::RoutingConfig;
@@ -524,6 +524,39 @@ api_key_env: GEMINI_API_KEY
         let yaml = r#"
 token: "${secret:discord_token}"
 token_env: DISCORD_TOKEN
+"#;
+        let parsed = serde_yaml::from_str::<ChannelConfig>(yaml);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn channel_config_defaults_to_streaming_output() {
+        let parsed: ChannelConfig = serde_yaml::from_str("{}\n").expect("valid yaml");
+        assert_eq!(parsed.output, ChannelOutputMode::Streaming);
+    }
+
+    #[test]
+    fn channel_config_accepts_streaming_output() {
+        let yaml = r#"
+output: streaming
+"#;
+        let parsed = serde_yaml::from_str::<ChannelConfig>(yaml).expect("valid yaml");
+        assert_eq!(parsed.output, ChannelOutputMode::Streaming);
+    }
+
+    #[test]
+    fn channel_config_accepts_normal_output() {
+        let yaml = r#"
+output: normal
+"#;
+        let parsed = serde_yaml::from_str::<ChannelConfig>(yaml).expect("valid yaml");
+        assert_eq!(parsed.output, ChannelOutputMode::Normal);
+    }
+
+    #[test]
+    fn channel_config_rejects_unknown_output() {
+        let yaml = r#"
+output: fancy
 "#;
         let parsed = serde_yaml::from_str::<ChannelConfig>(yaml);
         assert!(parsed.is_err());

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use tokio::task::JoinHandle;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio::time::{Duration, sleep};
 use tracing::{Instrument, info_span};
 
 use crate::channels::{Channel, InboundMessage};
-use crate::config::{GatewayChannelKind, RoutingConfig};
+use crate::config::{ChannelOutputMode, GatewayChannelKind, RoutingConfig};
 use crate::error::FrameworkError;
 
 mod policy;
@@ -17,6 +17,7 @@ mod transport;
 
 pub struct Gateway {
     channels: HashMap<GatewayChannelKind, Arc<dyn Channel>>,
+    output_modes: HashMap<GatewayChannelKind, ChannelOutputMode>,
     inbound_policy: RoutingConfig,
 }
 
@@ -39,9 +40,14 @@ impl Drop for GatewayListeners {
 }
 
 impl Gateway {
-    pub fn new(channels: HashMap<GatewayChannelKind, Arc<dyn Channel>>, inbound_policy: RoutingConfig) -> Self {
+    pub fn new(
+        channels: HashMap<GatewayChannelKind, Arc<dyn Channel>>,
+        output_modes: HashMap<GatewayChannelKind, ChannelOutputMode>,
+        inbound_policy: RoutingConfig,
+    ) -> Self {
         Self {
             channels,
+            output_modes,
             inbound_policy,
         }
     }
@@ -114,6 +120,44 @@ impl Gateway {
         channel.send_message(&inbound.channel_id, content).await
     }
 
+    pub async fn send_message_with_id(
+        &self,
+        inbound: &InboundMessage,
+        content: &str,
+    ) -> Result<Option<String>, FrameworkError> {
+        let channel = transport::channel_for_source(&self.channels, inbound.source_channel)?;
+        channel
+            .send_message_with_id(&inbound.channel_id, content)
+            .await
+    }
+
+    pub fn supports_message_editing(
+        &self,
+        inbound: &InboundMessage,
+    ) -> Result<bool, FrameworkError> {
+        let channel = transport::channel_for_source(&self.channels, inbound.source_channel)?;
+        Ok(channel.supports_message_editing())
+    }
+
+    pub fn output_mode(&self, inbound: &InboundMessage) -> ChannelOutputMode {
+        self.output_modes
+            .get(&inbound.source_channel)
+            .copied()
+            .unwrap_or(ChannelOutputMode::Streaming)
+    }
+
+    pub async fn edit_message(
+        &self,
+        inbound: &InboundMessage,
+        message_id: &str,
+        content: &str,
+    ) -> Result<(), FrameworkError> {
+        let channel = transport::channel_for_source(&self.channels, inbound.source_channel)?;
+        channel
+            .edit_message(&inbound.channel_id, message_id, content)
+            .await
+    }
+
     pub async fn add_reaction(
         &self,
         source_channel: GatewayChannelKind,
@@ -144,7 +188,7 @@ mod tests {
 
     use super::Gateway;
     use crate::channels::{Channel, ChannelInbound};
-    use crate::config::{GatewayChannelKind, RoutingConfig};
+    use crate::config::{ChannelOutputMode, GatewayChannelKind, RoutingConfig};
     use crate::error::FrameworkError;
 
     struct SingleInboundChannel {
@@ -200,7 +244,11 @@ mod tests {
         let mut channels = HashMap::new();
         channels.insert(GatewayChannelKind::Discord, channel);
         let (tx, mut rx) = mpsc::channel(1);
-        let gateway = Gateway::new(channels, RoutingConfig::default());
+        let gateway = Gateway::new(
+            channels,
+            HashMap::from([(GatewayChannelKind::Discord, ChannelOutputMode::Streaming)]),
+            RoutingConfig::default(),
+        );
         let _listeners = gateway.start(tx);
         let next = tokio::time::timeout(Duration::from_secs(1), rx.recv())
             .await

--- a/src/invoke.rs
+++ b/src/invoke.rs
@@ -71,6 +71,7 @@ impl AgentInvoker for DirectAgentInvoker {
             completion_tx: None,
             completion_route: None,
             source_message_id: None,
+            on_text_delta: None,
         };
         self.react_loop
             .upgrade()
@@ -119,6 +120,7 @@ impl AgentInvoker for DirectAgentInvoker {
             completion_tx: None,
             completion_route: None,
             source_message_id: None,
+            on_text_delta: None,
         };
         self.react_loop
             .upgrade()
@@ -150,7 +152,9 @@ mod tests {
         DynMemory, LongTermFactSummary, LongTermForgetResult, MemorizeResult, Memory,
         MemoryRecallHit, MemoryStoreScope, StoredMessage, StoredRole,
     };
-    use crate::providers::{Message, Provider, ProviderFactory, ProviderResponse, Role, ToolDefinition};
+    use crate::providers::{
+        Message, Provider, ProviderFactory, ProviderResponse, Role, ToolDefinition,
+    };
     use crate::react::ReactLoop;
     use crate::tools::skill::SkillFactory;
     use crate::tools::{
@@ -363,7 +367,10 @@ mod tests {
         Arc::new(ReactLoop::new(
             ProviderFactory::from_parts(HashMap::from([(
                 "default".to_owned(),
-                (Box::new(ForwardProvider { inner: provider }) as Box<dyn Provider>, true),
+                (
+                    Box::new(ForwardProvider { inner: provider }) as Box<dyn Provider>,
+                    true,
+                ),
             )])),
             default_factory(),
             SkillFactory::new(PathBuf::from("/tmp/simpleclaw-invoke-skills")),

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -1,12 +1,19 @@
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error};
 
 use crate::config::{GeminiProviderConfig, ProviderEntryConfig};
 use crate::error::FrameworkError;
 
-use super::types::{Message, Provider, ProviderResponse, Role, ToolCall, ToolDefinition};
+use super::types::{
+    Message, Provider, ProviderResponse, ProviderStream, Role, StreamEvent, ToolCall,
+    ToolDefinition,
+};
 
 pub struct GeminiProvider {
     config: GeminiProviderConfig,
@@ -39,6 +46,14 @@ impl GeminiProvider {
     fn endpoint(&self) -> String {
         format!(
             "{}/models/{}:generateContent",
+            self.config.api_base.trim_end_matches('/'),
+            self.config.model
+        )
+    }
+
+    fn stream_endpoint(&self) -> String {
+        format!(
+            "{}/models/{}:streamGenerateContent",
             self.config.api_base.trim_end_matches('/'),
             self.config.model
         )
@@ -144,6 +159,207 @@ fn summarize_gemini_error_body(body: &str) -> String {
     preview_text(trimmed, ERROR_BODY_PREVIEW_CHARS)
 }
 
+fn build_request_body(system_prompt: &str, history: &[Message], tools: &[ToolDefinition]) -> Value {
+    let function_declarations: Vec<Value> = tools
+        .iter()
+        .map(|tool| {
+            let schema: Value = serde_json::from_str(&tool.input_schema_json)
+                .unwrap_or_else(|_| json!({ "type": "object" }));
+            json!({
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": schema,
+            })
+        })
+        .collect();
+
+    let contents = build_gemini_contents(history);
+
+    json!({
+        "system_instruction": {
+            "parts": [{"text": system_prompt}]
+        },
+        "contents": contents,
+        "tools": [{
+            "functionDeclarations": function_declarations
+        }]
+    })
+}
+
+fn parse_provider_response(response_value: &Value) -> ProviderResponse {
+    let mut output_text: Option<String> = None;
+    let mut tool_calls = Vec::new();
+
+    if let Some(parts) = response_value
+        .get("candidates")
+        .and_then(|c| c.as_array())
+        .and_then(|c| c.first())
+        .and_then(|c| c.get("content"))
+        .and_then(|c| c.get("parts"))
+        .and_then(|p| p.as_array())
+    {
+        for part in parts {
+            if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                match output_text.as_mut() {
+                    Some(existing) if !existing.is_empty() => {
+                        existing.push_str(&format!("\n{text}"))
+                    }
+                    Some(existing) => existing.push_str(text),
+                    None => output_text = Some(text.to_owned()),
+                }
+            }
+
+            if let Some(function_call) = parse_tool_call_part(part) {
+                tool_calls.push(function_call);
+            }
+        }
+    }
+
+    ProviderResponse {
+        output_text,
+        tool_calls,
+    }
+}
+
+fn parse_tool_call_part(part: &Value) -> Option<ToolCall> {
+    let function_call = part.get("functionCall")?;
+    let name = function_call
+        .get("name")
+        .and_then(|n| n.as_str())
+        .unwrap_or("")
+        .to_owned();
+    if name.is_empty() {
+        return None;
+    }
+    let id = function_call
+        .get("id")
+        .or_else(|| function_call.get("callId"))
+        .and_then(|value| value.as_str())
+        .map(str::to_owned);
+    let args = function_call
+        .get("args")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    Some(ToolCall {
+        id,
+        name,
+        args_json: args.to_string(),
+    })
+}
+
+#[derive(Default)]
+struct GeminiStreamAccumulator {
+    line_buffer: String,
+    event_data_lines: Vec<String>,
+    tool_call_indices_by_id: BTreeMap<String, usize>,
+    tool_calls: Vec<ToolCall>,
+}
+
+impl GeminiStreamAccumulator {
+    fn push_bytes(
+        &mut self,
+        bytes: &[u8],
+        events: &mut Vec<StreamEvent>,
+    ) -> Result<(), FrameworkError> {
+        let chunk = std::str::from_utf8(bytes).map_err(|err| {
+            FrameworkError::Provider(format!("invalid gemini stream bytes: {err}"))
+        })?;
+        self.line_buffer.push_str(chunk);
+
+        while let Some(newline_index) = self.line_buffer.find('\n') {
+            let mut line = self.line_buffer[..newline_index].to_owned();
+            self.line_buffer.drain(..=newline_index);
+            if line.ends_with('\r') {
+                line.pop();
+            }
+            self.process_line(&line, events)?;
+        }
+        Ok(())
+    }
+
+    fn finish(mut self, events: &mut Vec<StreamEvent>) -> Result<(), FrameworkError> {
+        if !self.line_buffer.is_empty() {
+            let mut trailing = std::mem::take(&mut self.line_buffer);
+            if trailing.ends_with('\r') {
+                trailing.pop();
+            }
+            self.process_line(&trailing, events)?;
+        }
+        self.flush_event(events)?;
+        for tool_call in self.tool_calls {
+            events.push(StreamEvent::ToolCallComplete(tool_call));
+        }
+        events.push(StreamEvent::Done);
+        Ok(())
+    }
+
+    fn process_line(
+        &mut self,
+        line: &str,
+        events: &mut Vec<StreamEvent>,
+    ) -> Result<(), FrameworkError> {
+        if line.is_empty() {
+            self.flush_event(events)?;
+            return Ok(());
+        }
+
+        if let Some(data) = line.strip_prefix("data:") {
+            self.event_data_lines.push(data.trim_start().to_owned());
+        }
+        Ok(())
+    }
+
+    fn flush_event(&mut self, events: &mut Vec<StreamEvent>) -> Result<(), FrameworkError> {
+        if self.event_data_lines.is_empty() {
+            return Ok(());
+        }
+
+        let payload = self.event_data_lines.join("\n");
+        self.event_data_lines.clear();
+        if payload.trim() == "[DONE]" {
+            return Ok(());
+        }
+
+        let value: Value = serde_json::from_str(&payload).map_err(|err| {
+            FrameworkError::Provider(format!("invalid gemini stream event: {err}"))
+        })?;
+
+        if let Some(parts) = value
+            .get("candidates")
+            .and_then(|c| c.as_array())
+            .and_then(|c| c.first())
+            .and_then(|c| c.get("content"))
+            .and_then(|c| c.get("parts"))
+            .and_then(|p| p.as_array())
+        {
+            for part in parts {
+                if let Some(text) = part.get("text").and_then(|t| t.as_str())
+                    && !text.is_empty()
+                {
+                    events.push(StreamEvent::TextDelta(text.to_owned()));
+                }
+
+                if let Some(tool_call) = parse_tool_call_part(part) {
+                    if let Some(id) = tool_call.id.clone() {
+                        if let Some(index) = self.tool_call_indices_by_id.get(&id).copied() {
+                            self.tool_calls[index] = tool_call;
+                        } else {
+                            self.tool_call_indices_by_id
+                                .insert(id, self.tool_calls.len());
+                            self.tool_calls.push(tool_call);
+                        }
+                    } else {
+                        self.tool_calls.push(tool_call);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Provider for GeminiProvider {
     #[tracing::instrument(name = "provider.generate", skip(self, system_prompt, history, tools))]
@@ -156,31 +372,7 @@ impl Provider for GeminiProvider {
         let request_started = std::time::Instant::now();
         let api_key = self.api_key()?;
         let url = self.endpoint();
-
-        let function_declarations: Vec<Value> = tools
-            .iter()
-            .map(|tool| {
-                let schema: Value = serde_json::from_str(&tool.input_schema_json)
-                    .unwrap_or_else(|_| json!({ "type": "object" }));
-                json!({
-                    "name": tool.name,
-                    "description": tool.description,
-                    "parameters": schema,
-                })
-            })
-            .collect();
-
-        let contents = build_gemini_contents(history);
-
-        let body = json!({
-            "system_instruction": {
-                "parts": [{"text": system_prompt}]
-            },
-            "contents": contents,
-            "tools": [{
-                "functionDeclarations": function_declarations
-            }]
-        });
+        let body = build_request_body(system_prompt, history, tools);
         debug!(status = "started", "provider request");
 
         let response = self
@@ -233,65 +425,117 @@ impl Provider for GeminiProvider {
             FrameworkError::Provider(format!("invalid gemini response: {e}"))
         })?;
 
-        let mut output_text = None;
-        let mut tool_calls = Vec::new();
-
-        if let Some(parts) = response_value
-            .get("candidates")
-            .and_then(|c| c.as_array())
-            .and_then(|c| c.first())
-            .and_then(|c| c.get("content"))
-            .and_then(|c| c.get("parts"))
-            .and_then(|p| p.as_array())
-        {
-            for part in parts {
-                if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                    let merged = match output_text.take() {
-                        Some(existing) => format!("{existing}\n{text}"),
-                        None => text.to_owned(),
-                    };
-                    output_text = Some(merged);
-                }
-
-                if let Some(function_call) = part.get("functionCall") {
-                    let name = function_call
-                        .get("name")
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("")
-                        .to_owned();
-                    if name.is_empty() {
-                        continue;
-                    }
-                    let id = function_call
-                        .get("id")
-                        .or_else(|| function_call.get("callId"))
-                        .and_then(|value| value.as_str())
-                        .map(str::to_owned);
-
-                    let args = function_call
-                        .get("args")
-                        .cloned()
-                        .unwrap_or_else(|| json!({}));
-
-                    tool_calls.push(ToolCall {
-                        id,
-                        name,
-                        args_json: args.to_string(),
-                    });
-                }
-            }
-        }
-
         debug!(
             status = "completed",
             elapsed_ms = request_started.elapsed().as_millis() as u64,
             "provider request"
         );
 
-        Ok(ProviderResponse {
-            output_text,
-            tool_calls,
-        })
+        Ok(parse_provider_response(&response_value))
+    }
+
+    #[tracing::instrument(
+        name = "provider.generate_stream",
+        skip(self, system_prompt, history, tools)
+    )]
+    async fn generate_stream(
+        &self,
+        system_prompt: &str,
+        history: &[Message],
+        tools: &[ToolDefinition],
+    ) -> Result<ProviderStream, FrameworkError> {
+        let request_started = std::time::Instant::now();
+        let api_key = self.api_key()?;
+        let url = self.stream_endpoint();
+        let body = build_request_body(system_prompt, history, tools);
+        debug!(status = "started", "provider stream request");
+
+        let response = self
+            .client
+            .post(url)
+            .query(&[("alt", "sse"), ("key", api_key.as_str())])
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                error!(
+                    status = "failed",
+                    error_kind = "http_send",
+                    elapsed_ms = request_started.elapsed().as_millis() as u64,
+                    error = %e,
+                    "provider stream request"
+                );
+                FrameworkError::Provider(format!("gemini stream request failed: {e}"))
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response.text().await.unwrap_or_default();
+            let error_summary = summarize_gemini_error_body(&error_body);
+            let error_body_preview = preview_text(&error_body, ERROR_BODY_PREVIEW_CHARS);
+
+            error!(
+                status = "failed",
+                error_kind = "http_status",
+                http_status = %status,
+                elapsed_ms = request_started.elapsed().as_millis() as u64,
+                response_error = %error_summary,
+                response_body = %error_body_preview,
+                "provider stream request"
+            );
+            return Err(FrameworkError::Provider(format!(
+                "gemini returned {}: {}",
+                status, error_summary
+            )));
+        }
+
+        let mut byte_stream = response.bytes_stream();
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            let mut accumulator = GeminiStreamAccumulator::default();
+            while let Some(chunk) = byte_stream.next().await {
+                match chunk {
+                    Ok(bytes) => {
+                        let mut events = Vec::new();
+                        match accumulator.push_bytes(&bytes, &mut events) {
+                            Ok(()) => {
+                                for event in events {
+                                    if tx.send(event).is_err() {
+                                        return;
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                let _ = tx.send(StreamEvent::Error(err.to_string()));
+                                return;
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        let _ = tx.send(StreamEvent::Error(format!(
+                            "gemini stream read failed: {err}"
+                        )));
+                        return;
+                    }
+                }
+            }
+
+            let mut events = Vec::new();
+            match accumulator.finish(&mut events) {
+                Ok(()) => {
+                    for event in events {
+                        if tx.send(event).is_err() {
+                            return;
+                        }
+                    }
+                }
+                Err(err) => {
+                    let _ = tx.send(StreamEvent::Error(err.to_string()));
+                }
+            }
+        });
+
+        Ok(Box::pin(UnboundedReceiverStream::new(rx)))
     }
 }
 
@@ -299,8 +543,11 @@ impl Provider for GeminiProvider {
 mod tests {
     use serde_json::json;
 
-    use super::{build_gemini_contents, preview_text, summarize_gemini_error_body};
-    use crate::providers::{Message, Role, ToolCall, ToolResult};
+    use super::{
+        GeminiStreamAccumulator, build_gemini_contents, parse_provider_response, preview_text,
+        summarize_gemini_error_body,
+    };
+    use crate::providers::{Message, ProviderResponse, Role, StreamEvent, ToolCall, ToolResult};
 
     #[test]
     fn encodes_assistant_function_call_part() {
@@ -371,5 +618,108 @@ mod tests {
     #[test]
     fn preview_text_truncates_by_character_count() {
         assert_eq!(preview_text("abcdef", 4), "abcd");
+    }
+
+    #[test]
+    fn parses_provider_response_text_and_tool_calls() {
+        let response = parse_provider_response(&json!({
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        { "text": "hello" },
+                        { "functionCall": { "name": "clock", "id": "call-1", "args": { "timezone": "UTC" } } }
+                    ]
+                }
+            }]
+        }));
+
+        assert_eq!(
+            response,
+            ProviderResponse {
+                output_text: Some("hello".to_owned()),
+                tool_calls: vec![ToolCall {
+                    id: Some("call-1".to_owned()),
+                    name: "clock".to_owned(),
+                    args_json: r#"{"timezone":"UTC"}"#.to_owned(),
+                }],
+            }
+        );
+    }
+
+    #[test]
+    fn stream_accumulator_handles_split_frames_and_buffers_tool_calls_until_finish() {
+        let mut accumulator = GeminiStreamAccumulator::default();
+        let mut events = Vec::new();
+        accumulator
+            .push_bytes(
+                b"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hel\"}]}}]}\n\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"lo\"},{\"functionCall\":{\"name\":\"clock\",\"id\":\"call-1\",\"args\":{\"timezone\":\"UTC\"}}}]}}]}",
+                &mut events,
+            )
+            .expect("first chunk should parse");
+        accumulator
+            .push_bytes(b"\n\n", &mut events)
+            .expect("second chunk should parse");
+        accumulator
+            .finish(&mut events)
+            .expect("finish should flush remaining events");
+
+        assert_eq!(
+            events,
+            vec![
+                StreamEvent::TextDelta("hel".to_owned()),
+                StreamEvent::TextDelta("lo".to_owned()),
+                StreamEvent::ToolCallComplete(ToolCall {
+                    id: Some("call-1".to_owned()),
+                    name: "clock".to_owned(),
+                    args_json: r#"{"timezone":"UTC"}"#.to_owned(),
+                }),
+                StreamEvent::Done,
+            ]
+        );
+    }
+
+    #[test]
+    fn stream_accumulator_preserves_duplicate_idless_tool_calls() {
+        let mut accumulator = GeminiStreamAccumulator::default();
+        let mut events = Vec::new();
+        accumulator
+            .push_bytes(
+                br#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"clock","args":{"timezone":"UTC"}}}]}}]}
+
+data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"clock","args":{"timezone":"UTC"}}}]}}]}
+
+"#,
+                &mut events,
+            )
+            .expect("stream frames should parse");
+        accumulator
+            .finish(&mut events)
+            .expect("finish should flush remaining events");
+
+        assert_eq!(
+            events,
+            vec![
+                StreamEvent::ToolCallComplete(ToolCall {
+                    id: None,
+                    name: "clock".to_owned(),
+                    args_json: r#"{"timezone":"UTC"}"#.to_owned(),
+                }),
+                StreamEvent::ToolCallComplete(ToolCall {
+                    id: None,
+                    name: "clock".to_owned(),
+                    args_json: r#"{"timezone":"UTC"}"#.to_owned(),
+                }),
+                StreamEvent::Done,
+            ]
+        );
+    }
+
+    #[test]
+    fn stream_accumulator_reports_invalid_json() {
+        let mut accumulator = GeminiStreamAccumulator::default();
+        let mut events = Vec::new();
+        let err = accumulator.push_bytes(b"data: not-json\n\n", &mut events);
+
+        assert!(err.is_err());
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -3,4 +3,8 @@ mod registry;
 mod types;
 
 pub use registry::{ProviderFactory, ProviderRegistry};
-pub use types::{Message, Provider, ProviderResponse, Role, ToolCall, ToolDefinition, ToolResult};
+#[allow(unused_imports)]
+pub use types::{
+    Message, Provider, ProviderResponse, ProviderStream, Role, StreamEvent, ToolCall,
+    ToolDefinition, ToolResult, provider_response_to_stream,
+};

--- a/src/providers/types.rs
+++ b/src/providers/types.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::pin::Pin;
+use tokio_stream::Stream;
 
 use crate::error::FrameworkError;
 
@@ -23,7 +25,7 @@ pub struct Message {
     pub tool_results: Vec<ToolResult>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolCall {
     #[serde(default)]
     pub id: Option<String>,
@@ -75,10 +77,34 @@ pub struct ToolDefinition {
     pub input_schema_json: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProviderResponse {
     pub output_text: Option<String>,
     pub tool_calls: Vec<ToolCall>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum StreamEvent {
+    TextDelta(String),
+    ToolCallComplete(ToolCall),
+    Done,
+    Error(String),
+}
+
+pub type ProviderStream = Pin<Box<dyn Stream<Item = StreamEvent> + Send>>;
+
+pub fn provider_response_to_stream(response: ProviderResponse) -> ProviderStream {
+    let mut events = Vec::new();
+    if let Some(text) = response.output_text
+        && !text.is_empty()
+    {
+        events.push(StreamEvent::TextDelta(text));
+    }
+    for tool_call in response.tool_calls {
+        events.push(StreamEvent::ToolCallComplete(tool_call));
+    }
+    events.push(StreamEvent::Done);
+    Box::pin(tokio_stream::iter(events))
 }
 
 #[async_trait]
@@ -89,4 +115,48 @@ pub trait Provider: Send + Sync {
         history: &[Message],
         tools: &[ToolDefinition],
     ) -> Result<ProviderResponse, FrameworkError>;
+
+    async fn generate_stream(
+        &self,
+        system_prompt: &str,
+        history: &[Message],
+        tools: &[ToolDefinition],
+    ) -> Result<ProviderStream, FrameworkError> {
+        let response = self.generate(system_prompt, history, tools).await?;
+        Ok(provider_response_to_stream(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio_stream::StreamExt;
+
+    use super::{ProviderResponse, StreamEvent, ToolCall, provider_response_to_stream};
+
+    #[tokio::test]
+    async fn provider_response_to_stream_emits_text_tool_calls_and_done() {
+        let response = ProviderResponse {
+            output_text: Some("hello".to_owned()),
+            tool_calls: vec![ToolCall {
+                id: Some("call-1".to_owned()),
+                name: "clock".to_owned(),
+                args_json: r#"{"timezone":"UTC"}"#.to_owned(),
+            }],
+        };
+
+        let events: Vec<StreamEvent> = provider_response_to_stream(response).collect().await;
+
+        assert_eq!(
+            events,
+            vec![
+                StreamEvent::TextDelta("hello".to_owned()),
+                StreamEvent::ToolCallComplete(ToolCall {
+                    id: Some("call-1".to_owned()),
+                    name: "clock".to_owned(),
+                    args_json: r#"{"timezone":"UTC"}"#.to_owned(),
+                }),
+                StreamEvent::Done,
+            ]
+        );
+    }
 }

--- a/src/react.rs
+++ b/src/react.rs
@@ -2,7 +2,7 @@ use crate::dispatch::{DispatchAction, ToolDispatcher, ToolExecutionResult};
 use crate::error::FrameworkError;
 use crate::gateway::Gateway;
 use crate::providers::ProviderFactory;
-use crate::providers::{Message, Provider, Role};
+use crate::providers::{Message, Provider, ProviderResponse, Role, StreamEvent};
 use crate::reply_policy::no_reply_prompt_instruction;
 use crate::tools::ProcessManager;
 use crate::tools::skill::SkillFactory;
@@ -11,6 +11,7 @@ use crate::{channels::InboundMessage, memory::DynMemory};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
 use tracing::{Instrument, debug, error, info, info_span, warn};
 
 #[cfg(test)]
@@ -40,6 +41,7 @@ pub struct RunParams<'a> {
     pub completion_tx: Option<mpsc::Sender<InboundMessage>>,
     pub completion_route: Option<CompletionRoute>,
     pub source_message_id: Option<String>,
+    pub on_text_delta: Option<Arc<dyn Fn(&str) + Send + Sync>>,
 }
 
 #[derive(Debug, Clone)]
@@ -149,10 +151,15 @@ async fn run_loop(
         let provider_started = Instant::now();
         let turn_span = info_span!("provider.turn");
         debug!(parent: &turn_span, status = "started", "provider turn");
-        let response = match provider
-            .generate(&effective_system_prompt, history, &tool_specs)
-            .instrument(turn_span.clone())
-            .await
+        let response = match generate_provider_response(
+            provider,
+            &effective_system_prompt,
+            history,
+            &tool_specs,
+            params.on_text_delta.as_deref(),
+        )
+        .instrument(turn_span.clone())
+        .await
         {
             Ok(response) => response,
             Err(err) => {
@@ -219,6 +226,43 @@ async fn run_loop(
     })
 }
 
+async fn generate_provider_response(
+    provider: &dyn Provider,
+    system_prompt: &str,
+    history: &[Message],
+    tool_specs: &[crate::providers::ToolDefinition],
+    on_text_delta: Option<&(dyn Fn(&str) + Send + Sync)>,
+) -> Result<ProviderResponse, FrameworkError> {
+    let Some(on_text_delta) = on_text_delta else {
+        return provider.generate(system_prompt, history, tool_specs).await;
+    };
+
+    let mut stream = provider
+        .generate_stream(system_prompt, history, tool_specs)
+        .await?;
+    let mut output_text = String::new();
+    let mut tool_calls = Vec::new();
+
+    while let Some(event) = stream.next().await {
+        match event {
+            StreamEvent::TextDelta(delta) => {
+                output_text.push_str(&delta);
+                on_text_delta(&output_text);
+            }
+            StreamEvent::ToolCallComplete(tool_call) => tool_calls.push(tool_call),
+            StreamEvent::Done => break,
+            StreamEvent::Error(message) => {
+                return Err(FrameworkError::Provider(message));
+            }
+        }
+    }
+
+    Ok(ProviderResponse {
+        output_text: (!output_text.is_empty()).then_some(output_text),
+        tool_calls,
+    })
+}
+
 fn resolve_dispatcher(supports_native_tools: bool) -> &'static dyn ToolDispatcher {
     static NATIVE: crate::dispatch::NativeDispatcher = crate::dispatch::NativeDispatcher;
     static XML: crate::dispatch::XmlDispatcher = crate::dispatch::XmlDispatcher;
@@ -233,11 +277,42 @@ pub(crate) fn sanitize_log_preview(text: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use tokio_stream::iter;
 
     use crate::config::ToolsConfig;
+    use crate::providers::{ProviderStream, ToolCall, ToolDefinition};
     use crate::tools::default_factory;
 
     use super::*;
+
+    struct StreamingTestProvider {
+        response: ProviderResponse,
+        stream_events: Vec<StreamEvent>,
+    }
+
+    #[async_trait]
+    impl Provider for StreamingTestProvider {
+        async fn generate(
+            &self,
+            _system_prompt: &str,
+            _history: &[Message],
+            _tools: &[ToolDefinition],
+        ) -> Result<ProviderResponse, FrameworkError> {
+            Ok(self.response.clone())
+        }
+
+        async fn generate_stream(
+            &self,
+            _system_prompt: &str,
+            _history: &[Message],
+            _tools: &[ToolDefinition],
+        ) -> Result<ProviderStream, FrameworkError> {
+            Ok(Box::pin(iter(self.stream_events.clone())))
+        }
+    }
 
     fn tools_enabled(allowed: &[&str]) -> ToolsConfig {
         const ALL: &[&str] = &[
@@ -335,5 +410,67 @@ mod tests {
     fn sanitize_log_preview_flattens_newlines() {
         let preview = sanitize_log_preview("first line\nsecond\tline\r\nthird", 512);
         assert_eq!(preview, "first line second line third");
+    }
+
+    #[tokio::test]
+    async fn generate_provider_response_streams_accumulated_text_and_tool_calls() {
+        let provider = StreamingTestProvider {
+            response: ProviderResponse {
+                output_text: Some("unused".to_owned()),
+                tool_calls: Vec::new(),
+            },
+            stream_events: vec![
+                StreamEvent::TextDelta("hel".to_owned()),
+                StreamEvent::TextDelta("lo".to_owned()),
+                StreamEvent::ToolCallComplete(ToolCall {
+                    id: Some("call-1".to_owned()),
+                    name: "clock".to_owned(),
+                    args_json: r#"{"timezone":"UTC"}"#.to_owned(),
+                }),
+                StreamEvent::Done,
+            ],
+        };
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let on_text_delta: Arc<dyn Fn(&str) + Send + Sync> = {
+            let observed = Arc::clone(&observed);
+            Arc::new(move |text| {
+                observed
+                    .lock()
+                    .expect("test callback mutex should not be poisoned")
+                    .push(text.to_owned());
+            })
+        };
+
+        let response =
+            generate_provider_response(&provider, "system", &[], &[], Some(on_text_delta.as_ref()))
+                .await
+                .expect("streaming response should succeed");
+
+        assert_eq!(response.output_text.as_deref(), Some("hello"));
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(
+            observed
+                .lock()
+                .expect("test callback mutex should not be poisoned")
+                .clone(),
+            vec!["hel".to_owned(), "hello".to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_provider_response_returns_stream_errors() {
+        let provider = StreamingTestProvider {
+            response: ProviderResponse {
+                output_text: None,
+                tool_calls: Vec::new(),
+            },
+            stream_events: vec![StreamEvent::Error("boom".to_owned())],
+        };
+
+        let err = generate_provider_response(&provider, "system", &[], &[], Some(&|_| {}))
+            .await
+            .expect_err("streaming response should fail");
+
+        assert!(matches!(err, FrameworkError::Provider(message) if message == "boom"));
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,18 +1,19 @@
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use color_eyre::eyre::WrapErr;
 use rusqlite::{Connection, OpenFlags, params};
 use serde::Serialize;
+use tokio::sync::Notify;
 use tracing::{info, info_span};
 
 use crate::channels::InboundMessage;
 use crate::cli::{Cli, MemoryMode};
-use crate::config::{AgentEntryConfig, LoadedConfig};
+use crate::config::{AgentEntryConfig, ChannelOutputMode, LoadedConfig};
 use crate::paths::AppPaths;
 use crate::reply_policy::is_no_reply;
 
@@ -37,6 +38,259 @@ use session::{SessionHandler, SessionWorkerCoordinator};
 
 const SESSION_WORKER_IDLE_TIMEOUT_SECS: u64 = 300;
 const INBOUND_ACK_REACTION: &str = "👀";
+const STREAMING_EDIT_INTERVAL: Duration = Duration::from_millis(1_500);
+
+struct StreamingDisplay {
+    gateway: Arc<crate::gateway::Gateway>,
+    inbound: InboundMessage,
+    latest_content: String,
+    displayed_content: Option<String>,
+    message_id: Option<String>,
+    last_edit: Instant,
+    initial_send_attempted: bool,
+    send_in_flight: bool,
+    edit_in_flight: bool,
+    finalized: bool,
+    error_message: Option<String>,
+    notify: Arc<Notify>,
+}
+
+impl StreamingDisplay {
+    fn new(gateway: Arc<crate::gateway::Gateway>, inbound: InboundMessage) -> Self {
+        Self {
+            gateway,
+            inbound,
+            latest_content: String::new(),
+            displayed_content: None,
+            message_id: None,
+            last_edit: Instant::now() - STREAMING_EDIT_INTERVAL,
+            initial_send_attempted: false,
+            send_in_flight: false,
+            edit_in_flight: false,
+            finalized: false,
+            error_message: None,
+            notify: Arc::new(Notify::new()),
+        }
+    }
+}
+
+enum StreamingDisplayAction {
+    SendInitial {
+        gateway: Arc<crate::gateway::Gateway>,
+        inbound: InboundMessage,
+        content: String,
+    },
+    Edit {
+        gateway: Arc<crate::gateway::Gateway>,
+        inbound: InboundMessage,
+        message_id: String,
+        content: String,
+    },
+}
+
+fn spawn_streaming_display_update(display: &Arc<Mutex<StreamingDisplay>>, content: &str) {
+    {
+        let mut state = match display.lock() {
+            Ok(state) => state,
+            Err(_) => return,
+        };
+        state.latest_content = content.to_owned();
+        state.notify.notify_waiters();
+    }
+    spawn_next_streaming_display_action(display);
+}
+
+fn next_streaming_display_action(
+    display: &Arc<Mutex<StreamingDisplay>>,
+) -> Option<StreamingDisplayAction> {
+    let mut state = match display.lock() {
+        Ok(state) => state,
+        Err(_) => return None,
+    };
+
+    if state.latest_content.is_empty() {
+        return None;
+    }
+
+    if state.message_id.is_none() {
+        if state.send_in_flight || state.displayed_content.is_some() || state.initial_send_attempted
+        {
+            return None;
+        }
+        state.initial_send_attempted = true;
+        state.send_in_flight = true;
+        return Some(StreamingDisplayAction::SendInitial {
+            gateway: Arc::clone(&state.gateway),
+            inbound: state.inbound.clone(),
+            content: state.latest_content.clone(),
+        });
+    }
+
+    if state.edit_in_flight {
+        return None;
+    }
+
+    if state.displayed_content.as_deref() == Some(state.latest_content.as_str()) {
+        return None;
+    }
+
+    if !state.finalized && state.last_edit.elapsed() < STREAMING_EDIT_INTERVAL {
+        return None;
+    }
+
+    let message_id = state.message_id.clone()?;
+    state.edit_in_flight = true;
+    Some(StreamingDisplayAction::Edit {
+        gateway: Arc::clone(&state.gateway),
+        inbound: state.inbound.clone(),
+        message_id,
+        content: state.latest_content.clone(),
+    })
+}
+
+fn spawn_next_streaming_display_action(display: &Arc<Mutex<StreamingDisplay>>) {
+    let Some(action) = next_streaming_display_action(display) else {
+        return;
+    };
+    let display = Arc::clone(display);
+    tokio::spawn(async move {
+        match action {
+            StreamingDisplayAction::SendInitial {
+                gateway,
+                inbound,
+                content,
+            } => {
+                let result = gateway.send_message_with_id(&inbound, &content).await;
+                let mut should_retry = false;
+                {
+                    let mut state = match display.lock() {
+                        Ok(state) => state,
+                        Err(_) => return,
+                    };
+                    state.send_in_flight = false;
+                    match result {
+                        Ok(Some(message_id)) => {
+                            state.message_id = Some(message_id);
+                            state.displayed_content = Some(content);
+                            state.last_edit = Instant::now();
+                            state.error_message = None;
+                            should_retry = true;
+                        }
+                        Ok(None) => {
+                            state.displayed_content = Some(content);
+                            state.error_message = None;
+                        }
+                        Err(err) => {
+                            state.error_message = Some(err.to_string());
+                            tracing::warn!(
+                                status = "failed",
+                                error_kind = "streaming_initial_send",
+                                error = %err,
+                                trace_id = %inbound.trace_id,
+                                session_id = %inbound.session_key,
+                                "streaming initial send failed"
+                            );
+                        }
+                    }
+                    state.notify.notify_waiters();
+                }
+                if should_retry {
+                    spawn_next_streaming_display_action(&display);
+                }
+            }
+            StreamingDisplayAction::Edit {
+                gateway,
+                inbound,
+                message_id,
+                content,
+            } => {
+                let result = gateway.edit_message(&inbound, &message_id, &content).await;
+                let mut should_retry = false;
+                {
+                    let mut state = match display.lock() {
+                        Ok(state) => state,
+                        Err(_) => return,
+                    };
+                    state.edit_in_flight = false;
+                    if let Err(err) = result {
+                        state.error_message = Some(err.to_string());
+                        tracing::warn!(
+                            status = "failed",
+                            error_kind = "streaming_edit",
+                            error = %err,
+                            trace_id = %inbound.trace_id,
+                            session_id = %inbound.session_key,
+                            message_id = %message_id,
+                            "streaming edit failed"
+                        );
+                    } else {
+                        state.displayed_content = Some(content);
+                        state.last_edit = Instant::now();
+                        state.error_message = None;
+                        should_retry = true;
+                    }
+                    state.notify.notify_waiters();
+                }
+                if should_retry {
+                    spawn_next_streaming_display_action(&display);
+                }
+            }
+        }
+    });
+}
+
+async fn finalize_streaming_display(
+    display: &Arc<Mutex<StreamingDisplay>>,
+    content: &str,
+) -> Result<(), crate::error::FrameworkError> {
+    {
+        let mut state = display.lock().map_err(|_| {
+            crate::error::FrameworkError::Tool("streaming display mutex poisoned".to_owned())
+        })?;
+        state.latest_content = content.to_owned();
+        state.finalized = true;
+        state.notify.notify_waiters();
+    }
+    spawn_next_streaming_display_action(display);
+
+    loop {
+        let fallback = {
+            let state = display.lock().map_err(|_| {
+                crate::error::FrameworkError::Tool("streaming display mutex poisoned".to_owned())
+            })?;
+            if !state.send_in_flight
+                && !state.edit_in_flight
+                && let Some(error_message) = state.error_message.clone()
+            {
+                if state.message_id.is_some() || state.displayed_content.is_some() {
+                    return Err(crate::error::FrameworkError::Tool(error_message));
+                }
+            }
+            if !state.send_in_flight
+                && !state.edit_in_flight
+                && state.displayed_content.as_deref() == Some(content)
+            {
+                return Ok(());
+            }
+            if !state.send_in_flight
+                && !state.edit_in_flight
+                && state.message_id.is_none()
+                && state.displayed_content.is_none()
+            {
+                Some((Arc::clone(&state.gateway), state.inbound.clone()))
+            } else {
+                None
+            }
+        };
+
+        if let Some((gateway, inbound)) = fallback {
+            return gateway.send_message(&inbound, content).await;
+        }
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        spawn_next_streaming_display_action(display);
+    }
+}
 
 #[tracing::instrument(
     name = "inbound.message",
@@ -113,8 +367,31 @@ pub(crate) async fn handle_inbound_once(
     }
     tracing::debug!(status = "dispatching", "invoke inbound");
 
+    let streaming_display = (state.gateway.output_mode(&inbound) == ChannelOutputMode::Streaming
+        && state
+            .gateway
+            .supports_message_editing(&inbound)
+            .unwrap_or(false))
+    .then(|| {
+        Arc::new(Mutex::new(StreamingDisplay::new(
+            Arc::clone(&state.gateway),
+            inbound.clone(),
+        )))
+    });
+    let on_text_delta = streaming_display.as_ref().map(|streaming_display| {
+        let streaming_display = Arc::clone(streaming_display);
+        Arc::new(move |text: &str| {
+            spawn_streaming_display_update(&streaming_display, text);
+        }) as Arc<dyn Fn(&str) + Send + Sync>
+    });
+
     match runtime
-        .run(&inbound, &memory_session_id, state.context.as_ref())
+        .run(
+            &inbound,
+            &memory_session_id,
+            state.context.as_ref(),
+            on_text_delta,
+        )
         .await
     {
         Ok(outcome) => {
@@ -141,7 +418,12 @@ pub(crate) async fn handle_inbound_once(
                 outcome.memory_recall_hits,
                 inbound.source_channel,
             );
-            if let Err(err) = state.gateway.send_message(&inbound, &outbound).await {
+            let send_result = if let Some(streaming_display) = streaming_display.as_ref() {
+                finalize_streaming_display(streaming_display, &outbound).await
+            } else {
+                state.gateway.send_message(&inbound, &outbound).await
+            };
+            if let Err(err) = send_result {
                 tracing::error!(
                     status = "failed",
                     error_kind = "channel_send",
@@ -157,11 +439,15 @@ pub(crate) async fn handle_inbound_once(
                 error = %err,
                 "agent execution failed"
             );
-            if let Err(send_err) = state
-                .gateway
-                .send_message(&inbound, &state.safe_error_reply)
-                .await
-            {
+            let send_result = if let Some(streaming_display) = streaming_display.as_ref() {
+                finalize_streaming_display(streaming_display, &state.safe_error_reply).await
+            } else {
+                state
+                    .gateway
+                    .send_message(&inbound, &state.safe_error_reply)
+                    .await
+            };
+            if let Err(send_err) = send_result {
                 tracing::error!(
                     status = "failed",
                     error_kind = "safe_reply_send",
@@ -499,36 +785,43 @@ mod tests {
     use std::future::pending;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
     use async_trait::async_trait;
     use rusqlite::Connection;
-    use tokio::sync::{Mutex, mpsc};
+    use tokio::sync::{Mutex, Notify, mpsc};
     use tokio::time::{Duration, timeout};
 
     use super::{
-        INBOUND_ACK_REACTION, dispatch_inbound_with_ack, handle_inbound_once, query_long_memory,
-        query_short_memory,
+        INBOUND_ACK_REACTION, StreamingDisplay, dispatch_inbound_with_ack, handle_inbound_once,
+        query_long_memory, query_short_memory, spawn_streaming_display_update,
     };
-    use crate::agent::{AgentDirectory, AgentRuntime, AgentRuntimeConfig, RuntimeContext, ToolRuntime};
+    use crate::agent::{
+        AgentDirectory, AgentRuntime, AgentRuntimeConfig, RuntimeContext, ToolRuntime,
+    };
     use crate::channels::{Channel, ChannelInbound, InboundMessage};
     use crate::config::{
-        AgentInnerConfig, ExecutionDefaultsConfig, GatewayChannelKind, MemoryRecallConfig,
-        RoutingConfig,
+        AgentInnerConfig, ChannelOutputMode, ExecutionDefaultsConfig, GatewayChannelKind,
+        MemoryRecallConfig, RoutingConfig,
     };
     use crate::error::FrameworkError;
     use crate::gateway::Gateway;
     use crate::memory::{
-        DynMemory, LongTermFactSummary, LongTermForgetResult, MemorizeResult, Memory, MemoryRecallHit,
-        MemoryStoreScope, StoredMessage, StoredRole,
+        DynMemory, LongTermFactSummary, LongTermForgetResult, MemorizeResult, Memory,
+        MemoryRecallHit, MemoryStoreScope, StoredMessage, StoredRole,
     };
-    use crate::providers::{Message, Provider, ProviderFactory, ProviderResponse, ToolDefinition};
+    use crate::providers::{
+        Message, Provider, ProviderFactory, ProviderResponse, ProviderStream, StreamEvent,
+        ToolDefinition,
+    };
     use crate::react::ReactLoop;
-    use crate::tools::skill::SkillFactory;
     use crate::run::session::{SessionHandler, SessionWorkerCoordinator};
     use crate::telemetry::next_trace_id;
-    use crate::tools::{AgentInvokeRequest, AgentInvoker, InvokeOutcome, ProcessManager, default_factory};
+    use crate::tools::skill::SkillFactory;
+    use crate::tools::{
+        AgentInvokeRequest, AgentInvoker, InvokeOutcome, ProcessManager, default_factory,
+    };
 
     use super::composition::RuntimeState;
 
@@ -772,6 +1065,58 @@ mod tests {
         }
     }
 
+    struct StreamingProvider {
+        events: Vec<StreamEvent>,
+    }
+
+    impl StreamingProvider {
+        fn new(events: Vec<StreamEvent>) -> Self {
+            Self { events }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for StreamingProvider {
+        async fn generate(
+            &self,
+            _system_prompt: &str,
+            _history: &[Message],
+            _tools: &[ToolDefinition],
+        ) -> Result<ProviderResponse, FrameworkError> {
+            Ok(ProviderResponse {
+                output_text: None,
+                tool_calls: Vec::new(),
+            })
+        }
+
+        async fn generate_stream(
+            &self,
+            _system_prompt: &str,
+            _history: &[Message],
+            _tools: &[ToolDefinition],
+        ) -> Result<ProviderStream, FrameworkError> {
+            let (tx, rx) = mpsc::unbounded_channel();
+            let events = self.events.clone();
+            tokio::spawn(async move {
+                for event in events {
+                    match &event {
+                        StreamEvent::Done => {
+                            let _ = tx.send(event);
+                            break;
+                        }
+                        _ => {
+                            let _ = tx.send(event);
+                            tokio::time::sleep(Duration::from_millis(10)).await;
+                        }
+                    }
+                }
+            });
+            Ok(Box::pin(
+                tokio_stream::wrappers::UnboundedReceiverStream::new(rx),
+            ))
+        }
+    }
+
     struct ForwardProvider {
         inner: Arc<dyn Provider>,
     }
@@ -785,6 +1130,17 @@ mod tests {
             tools: &[ToolDefinition],
         ) -> Result<ProviderResponse, FrameworkError> {
             self.inner.generate(system_prompt, history, tools).await
+        }
+
+        async fn generate_stream(
+            &self,
+            system_prompt: &str,
+            history: &[Message],
+            tools: &[ToolDefinition],
+        ) -> Result<ProviderStream, FrameworkError> {
+            self.inner
+                .generate_stream(system_prompt, history, tools)
+                .await
         }
     }
 
@@ -807,12 +1163,34 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
     struct LifecycleChannel {
         outbound: Mutex<Vec<(String, String)>>,
+        outbound_with_id: Mutex<Vec<(String, String, String)>>,
+        edits: Mutex<Vec<(String, String, String)>>,
         typing_events: Mutex<Vec<String>>,
         fail_typing: AtomicBool,
         fail_send: AtomicBool,
+        editable: AtomicBool,
+        send_delay_ms: AtomicUsize,
+        edit_delay_ms: AtomicUsize,
+        next_message_id: AtomicUsize,
+    }
+
+    impl Default for LifecycleChannel {
+        fn default() -> Self {
+            Self {
+                outbound: Mutex::new(Vec::new()),
+                outbound_with_id: Mutex::new(Vec::new()),
+                edits: Mutex::new(Vec::new()),
+                typing_events: Mutex::new(Vec::new()),
+                fail_typing: AtomicBool::new(false),
+                fail_send: AtomicBool::new(false),
+                editable: AtomicBool::new(true),
+                send_delay_ms: AtomicUsize::new(0),
+                edit_delay_ms: AtomicUsize::new(0),
+                next_message_id: AtomicUsize::new(0),
+            }
+        }
     }
 
     impl LifecycleChannel {
@@ -830,8 +1208,37 @@ mod tests {
             }
         }
 
+        fn non_editable() -> Self {
+            Self {
+                editable: AtomicBool::new(false),
+                ..Default::default()
+            }
+        }
+
+        fn with_send_delay(ms: usize) -> Self {
+            Self {
+                send_delay_ms: AtomicUsize::new(ms),
+                ..Default::default()
+            }
+        }
+
+        fn with_edit_delay(ms: usize) -> Self {
+            Self {
+                edit_delay_ms: AtomicUsize::new(ms),
+                ..Default::default()
+            }
+        }
+
         async fn outbound(&self) -> Vec<(String, String)> {
             self.outbound.lock().await.clone()
+        }
+
+        async fn outbound_with_id(&self) -> Vec<(String, String, String)> {
+            self.outbound_with_id.lock().await.clone()
+        }
+
+        async fn edits(&self) -> Vec<(String, String, String)> {
+            self.edits.lock().await.clone()
         }
 
         async fn typing_events(&self) -> Vec<String> {
@@ -841,6 +1248,10 @@ mod tests {
 
     #[async_trait]
     impl Channel for LifecycleChannel {
+        fn supports_message_editing(&self) -> bool {
+            self.editable.load(Ordering::Relaxed)
+        }
+
         async fn send_message(
             &self,
             channel_id: &str,
@@ -869,6 +1280,55 @@ mod tests {
             self.typing_events.lock().await.push(channel_id.to_owned());
             if self.fail_typing.load(Ordering::Relaxed) {
                 return Err(FrameworkError::Tool("simulated typing failure".to_owned()));
+            }
+            Ok(())
+        }
+
+        async fn send_message_with_id(
+            &self,
+            channel_id: &str,
+            content: &str,
+        ) -> Result<Option<String>, FrameworkError> {
+            if !self.supports_message_editing() {
+                self.send_message(channel_id, content).await?;
+                return Ok(None);
+            }
+            let delay_ms = self.send_delay_ms.load(Ordering::Relaxed) as u64;
+            if delay_ms > 0 {
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            }
+            let message_id = format!(
+                "stream-msg-{}",
+                self.next_message_id.fetch_add(1, Ordering::Relaxed)
+            );
+            self.outbound_with_id.lock().await.push((
+                channel_id.to_owned(),
+                message_id.clone(),
+                content.to_owned(),
+            ));
+            if self.fail_send.load(Ordering::Relaxed) {
+                return Err(FrameworkError::Tool("simulated send failure".to_owned()));
+            }
+            Ok(Some(message_id))
+        }
+
+        async fn edit_message(
+            &self,
+            channel_id: &str,
+            message_id: &str,
+            content: &str,
+        ) -> Result<(), FrameworkError> {
+            let delay_ms = self.edit_delay_ms.load(Ordering::Relaxed) as u64;
+            if delay_ms > 0 {
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            }
+            self.edits.lock().await.push((
+                channel_id.to_owned(),
+                message_id.to_owned(),
+                content.to_owned(),
+            ));
+            if self.fail_send.load(Ordering::Relaxed) {
+                return Err(FrameworkError::Tool("simulated send failure".to_owned()));
             }
             Ok(())
         }
@@ -937,18 +1397,27 @@ mod tests {
     fn test_gateway(channel: Arc<dyn Channel>) -> Gateway {
         let mut channels = HashMap::new();
         channels.insert(GatewayChannelKind::Discord, channel);
-        Gateway::new(channels, RoutingConfig::default())
+        Gateway::new(
+            channels,
+            HashMap::from([(GatewayChannelKind::Discord, ChannelOutputMode::Streaming)]),
+            RoutingConfig::default(),
+        )
     }
 
     fn lifecycle_runtime_state(
         channel: Arc<LifecycleChannel>,
         provider: Arc<dyn Provider>,
         memory: DynMemory,
+        output_mode: ChannelOutputMode,
     ) -> RuntimeState {
         let mut channels: HashMap<GatewayChannelKind, Arc<dyn Channel>> = HashMap::new();
         channels.insert(GatewayChannelKind::Discord, channel);
         let (gateway_tx, _gateway_rx) = mpsc::channel(4);
-        let gateway = Arc::new(Gateway::new(channels, RoutingConfig::default()));
+        let gateway = Arc::new(Gateway::new(
+            channels,
+            HashMap::from([(GatewayChannelKind::Discord, output_mode)]),
+            RoutingConfig::default(),
+        ));
         let mut agent_config = AgentInnerConfig::default();
         agent_config.tools = agent_config.tools.with_disabled(&["cron"]);
         let runtime_config = AgentRuntimeConfig {
@@ -964,7 +1433,10 @@ mod tests {
         let react_loop = Arc::new(ReactLoop::new(
             ProviderFactory::from_parts(HashMap::from([(
                 "default".to_owned(),
-                (Box::new(ForwardProvider { inner: provider }) as Box<dyn Provider>, true),
+                (
+                    Box::new(ForwardProvider { inner: provider }) as Box<dyn Provider>,
+                    true,
+                ),
             )])),
             default_factory(),
             SkillFactory::new(PathBuf::from("/tmp/simpleclaw-run-skill-test")),
@@ -1097,7 +1569,11 @@ mod tests {
         let mut channels: HashMap<GatewayChannelKind, Arc<dyn Channel>> = HashMap::new();
         channels.insert(GatewayChannelKind::Discord, channel.clone());
         let (gateway_tx, _gateway_rx) = mpsc::channel(4);
-        let gateway = Arc::new(Gateway::new(channels, RoutingConfig::default()));
+        let gateway = Arc::new(Gateway::new(
+            channels,
+            HashMap::from([(GatewayChannelKind::Discord, ChannelOutputMode::Streaming)]),
+            RoutingConfig::default(),
+        ));
         let context = Arc::new(RuntimeContext {
             react_loop: Arc::new(ReactLoop::new(
                 ProviderFactory::from_parts(HashMap::new()),
@@ -1126,7 +1602,9 @@ mod tests {
         };
         let inbound = inbound_message();
 
-        handle_inbound_once(&state, inbound).await.expect("handler should not fail");
+        handle_inbound_once(&state, inbound)
+            .await
+            .expect("handler should not fail");
 
         let outbound = channel.outbound().await;
         assert_eq!(outbound.len(), 1);
@@ -1142,7 +1620,12 @@ mod tests {
         let memory_impl = Arc::new(FakeMemory::default());
         let memory: DynMemory = memory_impl.clone();
         let provider: Arc<dyn Provider> = Arc::new(StaticProvider::ok("unused"));
-        let state = lifecycle_runtime_state(channel.clone(), provider, memory);
+        let state = lifecycle_runtime_state(
+            channel.clone(),
+            provider,
+            memory,
+            ChannelOutputMode::Streaming,
+        );
         let mut inbound = inbound_message();
         inbound.invoke = false;
 
@@ -1164,16 +1647,22 @@ mod tests {
         let memory_impl = Arc::new(FakeMemory::default());
         let memory: DynMemory = memory_impl.clone();
         let provider: Arc<dyn Provider> = Arc::new(StaticProvider::ok("hello back"));
-        let state = lifecycle_runtime_state(channel.clone(), provider, memory);
+        let state = lifecycle_runtime_state(
+            channel.clone(),
+            provider,
+            memory,
+            ChannelOutputMode::Streaming,
+        );
 
         handle_inbound_once(&state, inbound_message())
             .await
             .expect("handler should succeed");
 
         assert_eq!(channel.typing_events().await.len(), 1);
-        let outbound = channel.outbound().await;
+        let outbound = channel.outbound_with_id().await;
         assert_eq!(outbound.len(), 1);
-        assert_eq!(outbound[0].1, "hello back");
+        assert_eq!(outbound[0].2, "hello back");
+        assert!(channel.edits().await.is_empty());
     }
 
     #[tokio::test]
@@ -1181,15 +1670,21 @@ mod tests {
         let channel = Arc::new(LifecycleChannel::default());
         let memory: DynMemory = Arc::new(FakeMemory::default());
         let provider: Arc<dyn Provider> = Arc::new(StaticProvider::err("boom"));
-        let state = lifecycle_runtime_state(channel.clone(), provider, memory);
+        let state = lifecycle_runtime_state(
+            channel.clone(),
+            provider,
+            memory,
+            ChannelOutputMode::Streaming,
+        );
 
         handle_inbound_once(&state, inbound_message())
             .await
             .expect("handler should swallow runtime failure");
 
-        let outbound = channel.outbound().await;
-        assert_eq!(outbound.len(), 1);
-        assert_eq!(outbound[0].1, "safe fallback");
+        let streamed = channel.outbound_with_id().await;
+        assert_eq!(streamed.len(), 1);
+        assert_eq!(streamed[0].2, "safe fallback");
+        assert!(channel.outbound().await.is_empty());
     }
 
     #[tokio::test]
@@ -1197,14 +1692,171 @@ mod tests {
         let channel = Arc::new(LifecycleChannel::with_send_failure());
         let memory: DynMemory = Arc::new(FakeMemory::default());
         let provider: Arc<dyn Provider> = Arc::new(StaticProvider::ok("reply"));
-        let state = lifecycle_runtime_state(channel.clone(), provider, memory);
+        let state = lifecycle_runtime_state(
+            channel.clone(),
+            provider,
+            memory,
+            ChannelOutputMode::Streaming,
+        );
 
         handle_inbound_once(&state, inbound_message())
             .await
             .expect("handler should succeed despite send failure");
 
+        let streamed = channel.outbound_with_id().await;
+        assert_eq!(streamed.len(), 1);
+        assert_eq!(streamed[0].2, "reply");
         let outbound = channel.outbound().await;
         assert_eq!(outbound.len(), 1);
         assert_eq!(outbound[0].1, "reply");
+    }
+
+    #[tokio::test]
+    async fn handle_inbound_once_uses_streaming_message_send_and_final_edit() {
+        let channel = Arc::new(LifecycleChannel::default());
+        let memory: DynMemory = Arc::new(FakeMemory::default());
+        let provider: Arc<dyn Provider> = Arc::new(StaticProvider::ok("streamed reply"));
+        let state = lifecycle_runtime_state(
+            channel.clone(),
+            provider,
+            memory,
+            ChannelOutputMode::Streaming,
+        );
+
+        handle_inbound_once(&state, inbound_message())
+            .await
+            .expect("handler should succeed");
+
+        let initial = channel.outbound_with_id().await;
+        assert_eq!(initial.len(), 1);
+        assert_eq!(initial[0].2, "streamed reply");
+        assert!(channel.edits().await.is_empty());
+        assert!(channel.outbound().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_inbound_once_waits_for_slow_initial_stream_send_without_duplicate_fallback() {
+        let channel = Arc::new(LifecycleChannel::with_send_delay(150));
+        let memory: DynMemory = Arc::new(FakeMemory::default());
+        let provider: Arc<dyn Provider> = Arc::new(StaticProvider::ok("slow streamed reply"));
+        let state = lifecycle_runtime_state(
+            channel.clone(),
+            provider,
+            memory,
+            ChannelOutputMode::Streaming,
+        );
+
+        handle_inbound_once(&state, inbound_message())
+            .await
+            .expect("handler should succeed");
+
+        let initial = channel.outbound_with_id().await;
+        assert_eq!(initial.len(), 1);
+        assert_eq!(initial[0].2, "slow streamed reply");
+        assert!(channel.edits().await.is_empty());
+        assert!(channel.outbound().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_inbound_once_uses_single_final_send_for_non_editable_channels() {
+        let channel = Arc::new(LifecycleChannel::non_editable());
+        let memory: DynMemory = Arc::new(FakeMemory::default());
+        let provider: Arc<dyn Provider> = Arc::new(StaticProvider::ok("plain reply"));
+        let state = lifecycle_runtime_state(
+            channel.clone(),
+            provider,
+            memory,
+            ChannelOutputMode::Streaming,
+        );
+
+        handle_inbound_once(&state, inbound_message())
+            .await
+            .expect("handler should succeed");
+
+        let outbound = channel.outbound().await;
+        assert_eq!(outbound.len(), 1);
+        assert_eq!(outbound[0].1, "plain reply");
+        assert!(channel.outbound_with_id().await.is_empty());
+        assert!(channel.edits().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_inbound_once_uses_single_final_send_when_output_mode_is_normal() {
+        let channel = Arc::new(LifecycleChannel::default());
+        let memory: DynMemory = Arc::new(FakeMemory::default());
+        let provider: Arc<dyn Provider> = Arc::new(StaticProvider::ok("plain reply"));
+        let state =
+            lifecycle_runtime_state(channel.clone(), provider, memory, ChannelOutputMode::Normal);
+
+        handle_inbound_once(&state, inbound_message())
+            .await
+            .expect("handler should succeed");
+
+        let outbound = channel.outbound().await;
+        assert_eq!(outbound.len(), 1);
+        assert_eq!(outbound[0].1, "plain reply");
+        assert!(channel.outbound_with_id().await.is_empty());
+        assert!(channel.edits().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_inbound_once_finalizes_after_in_flight_edit_without_duplicate_send() {
+        let channel = Arc::new(LifecycleChannel::with_edit_delay(150));
+        let memory: DynMemory = Arc::new(FakeMemory::default());
+        let provider: Arc<dyn Provider> = Arc::new(StreamingProvider::new(vec![
+            StreamEvent::TextDelta("hel".to_owned()),
+            StreamEvent::TextDelta("lo".to_owned()),
+            StreamEvent::Done,
+        ]));
+        let state = lifecycle_runtime_state(
+            channel.clone(),
+            provider,
+            memory,
+            ChannelOutputMode::Streaming,
+        );
+
+        handle_inbound_once(&state, inbound_message())
+            .await
+            .expect("handler should succeed");
+
+        let initial = channel.outbound_with_id().await;
+        assert_eq!(initial.len(), 1);
+        assert_eq!(initial[0].2, "hel");
+        let edits = channel.edits().await;
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].1, initial[0].1);
+        assert_eq!(edits[0].2, "hello");
+        assert!(channel.outbound().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn streaming_display_rate_limits_edit_spawns() {
+        let channel = Arc::new(LifecycleChannel::default());
+        let mut channels: HashMap<GatewayChannelKind, Arc<dyn Channel>> = HashMap::new();
+        channels.insert(GatewayChannelKind::Discord, channel.clone());
+        let gateway = Arc::new(Gateway::new(
+            channels,
+            HashMap::from([(GatewayChannelKind::Discord, ChannelOutputMode::Streaming)]),
+            RoutingConfig::default(),
+        ));
+        let display = Arc::new(std::sync::Mutex::new(StreamingDisplay {
+            gateway,
+            inbound: inbound_message(),
+            latest_content: "first".to_owned(),
+            displayed_content: Some("stale".to_owned()),
+            message_id: Some("stream-msg-1".to_owned()),
+            last_edit: Instant::now(),
+            initial_send_attempted: true,
+            send_in_flight: false,
+            edit_in_flight: false,
+            finalized: false,
+            error_message: None,
+            notify: Arc::new(Notify::new()),
+        }));
+
+        spawn_streaming_display_update(&display, "first");
+        tokio::time::sleep(Duration::from_millis(25)).await;
+
+        assert!(channel.edits().await.is_empty());
     }
 }

--- a/src/run/composition.rs
+++ b/src/run/composition.rs
@@ -12,7 +12,7 @@ use crate::agent::{
     load_system_prompt_for_workspace,
 };
 use crate::channels::{Channel, DiscordChannel, InboundMessage};
-use crate::config::{AgentEntryConfig, GatewayChannelKind, LoadedConfig};
+use crate::config::{AgentEntryConfig, ChannelOutputMode, GatewayChannelKind, LoadedConfig};
 use crate::gateway::Gateway;
 use crate::invoke::DirectAgentInvoker;
 use crate::memory::{DynMemory, MemoryStore};
@@ -293,7 +293,19 @@ pub(crate) async fn assemble_runtime_state(
     let (gateway_tx, gateway_rx) = tokio::sync::mpsc::channel::<InboundMessage>(1_024);
 
     let channels = deps.channel_factory.create_channels(loaded).await?;
-    let gateway = Arc::new(Gateway::new(channels, loaded.global.gateway.routing.clone()));
+    let output_modes = loaded
+        .global
+        .gateway
+        .channels
+        .iter()
+        .filter(|(_, config)| config.enabled)
+        .map(|(kind, config)| (*kind, config.output))
+        .collect::<HashMap<GatewayChannelKind, ChannelOutputMode>>();
+    let gateway = Arc::new(Gateway::new(
+        channels,
+        output_modes,
+        loaded.global.gateway.routing.clone(),
+    ));
 
     let context = Arc::new(RuntimeContext {
         react_loop,
@@ -353,13 +365,13 @@ mod tests {
     use crate::config::{
         AgentEntryConfig, GatewayChannelKind, GlobalConfig, LoadedConfig, MemoryRecallConfig,
     };
+    use crate::error::FrameworkError;
     use crate::memory::{
-        DynMemory, LongTermFactSummary, LongTermForgetResult, MemorizeResult, Memory, MemoryRecallHit,
-        MemoryStoreScope, StoredMessage, StoredRole,
+        DynMemory, LongTermFactSummary, LongTermForgetResult, MemorizeResult, Memory,
+        MemoryRecallHit, MemoryStoreScope, StoredMessage, StoredRole,
     };
     use crate::paths::AppPaths;
     use crate::providers::{Provider, ProviderFactory, ProviderResponse, ToolDefinition};
-    use crate::error::FrameworkError;
 
     #[derive(Default)]
     struct NoopMemory;
@@ -502,7 +514,8 @@ mod tests {
         async fn create_channels(
             &self,
             _loaded: &LoadedConfig,
-        ) -> color_eyre::Result<HashMap<GatewayChannelKind, Arc<dyn crate::channels::Channel>>> {
+        ) -> color_eyre::Result<HashMap<GatewayChannelKind, Arc<dyn crate::channels::Channel>>>
+        {
             Ok(HashMap::new())
         }
     }
@@ -549,7 +562,8 @@ mod tests {
     #[test]
     fn agent_workspace_memory_paths_uses_simpleclaw_memory_layout() {
         let workspace = PathBuf::from("/tmp/workspace");
-        let (memory_dir, short_term_path, long_term_path) = agent_workspace_memory_paths(&workspace);
+        let (memory_dir, short_term_path, long_term_path) =
+            agent_workspace_memory_paths(&workspace);
 
         assert_eq!(memory_dir, workspace.join(".simpleclaw").join("memory"));
         assert_eq!(short_term_path, memory_dir.join("short_term_memory.db"));
@@ -575,7 +589,10 @@ mod tests {
 
         assert_eq!(state.runtimes.len(), 1);
         assert!(state.runtimes.contains_key("default"));
-        assert_eq!(state.safe_error_reply, loaded.global.execution.defaults.safe_error_reply);
+        assert_eq!(
+            state.safe_error_reply,
+            loaded.global.execution.defaults.safe_error_reply
+        );
         assert!(state.context.agents.config("default").is_some());
         assert!(state.context.agents.memory("default").is_some());
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -510,9 +510,11 @@ impl Provider for StaticMockProvider {
 
 struct CaptureChannel {
     outbound: Mutex<Vec<TestOutboundMessage>>,
+    outbound_ids: Mutex<Vec<String>>,
     typing_events: AtomicUsize,
     listen_tx: tokio::sync::mpsc::Sender<ChannelInbound>,
     listen_rx: Mutex<tokio::sync::mpsc::Receiver<ChannelInbound>>,
+    next_message_id: AtomicUsize,
 }
 
 impl CaptureChannel {
@@ -520,9 +522,11 @@ impl CaptureChannel {
         let (listen_tx, listen_rx) = tokio::sync::mpsc::channel(1);
         Self {
             outbound: Mutex::new(Vec::new()),
+            outbound_ids: Mutex::new(Vec::new()),
             typing_events: AtomicUsize::new(0),
             listen_tx,
             listen_rx: Mutex::new(listen_rx),
+            next_message_id: AtomicUsize::new(0),
         }
     }
 
@@ -544,8 +548,58 @@ impl CaptureChannel {
 
 #[async_trait]
 impl Channel for CaptureChannel {
+    fn supports_message_editing(&self) -> bool {
+        true
+    }
+
     async fn send_message(&self, channel_id: &str, content: &str) -> Result<(), FrameworkError> {
         let mut outbound = self.outbound.lock().await;
+        outbound.push(TestOutboundMessage {
+            channel_id: channel_id.to_owned(),
+            content: content.to_owned(),
+        });
+        self.outbound_ids.lock().await.push(String::new());
+        Ok(())
+    }
+
+    async fn send_message_with_id(
+        &self,
+        channel_id: &str,
+        content: &str,
+    ) -> Result<Option<String>, FrameworkError> {
+        let message_id = format!(
+            "test-msg-{}",
+            self.next_message_id.fetch_add(1, Ordering::SeqCst)
+        );
+        let mut outbound = self.outbound.lock().await;
+        outbound.push(TestOutboundMessage {
+            channel_id: channel_id.to_owned(),
+            content: content.to_owned(),
+        });
+        self.outbound_ids.lock().await.push(message_id.clone());
+        Ok(Some(message_id))
+    }
+
+    async fn edit_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        content: &str,
+    ) -> Result<(), FrameworkError> {
+        let mut outbound = self.outbound.lock().await;
+        let outbound_ids = self.outbound_ids.lock().await;
+        if let Some((index, _)) = outbound_ids
+            .iter()
+            .enumerate()
+            .find(|(_, candidate)| candidate.as_str() == message_id)
+        {
+            outbound[index] = TestOutboundMessage {
+                channel_id: channel_id.to_owned(),
+                content: content.to_owned(),
+            };
+            return Ok(());
+        }
+
         outbound.push(TestOutboundMessage {
             channel_id: channel_id.to_owned(),
             content: content.to_owned(),

--- a/src/tools/builtin/exec.rs
+++ b/src/tools/builtin/exec.rs
@@ -245,7 +245,10 @@ mod tests {
             .err()
             .expect("empty command should fail");
 
-        assert!(err.to_string().contains("exec requires a non-empty command"));
+        assert!(
+            err.to_string()
+                .contains("exec requires a non-empty command")
+        );
     }
 
     #[tokio::test]
@@ -255,18 +258,23 @@ mod tests {
             "allow_background": false,
             "sandbox": { "enabled": false }
         }))
-            .expect("config should apply");
+        .expect("config should apply");
         let ctx = test_ctx().await;
 
         let err = tool
-            .execute(&ctx, "{\"command\":\"sleep 1\",\"background\":true}", "sess-1")
+            .execute(
+                &ctx,
+                "{\"command\":\"sleep 1\",\"background\":true}",
+                "sess-1",
+            )
             .await
             .err()
             .expect("background execution should fail");
 
-        assert!(err
-            .to_string()
-            .contains("exec background mode is disabled by tools.exec.allow_background"));
+        assert!(
+            err.to_string()
+                .contains("exec background mode is disabled by tools.exec.allow_background")
+        );
     }
 
     #[tokio::test]
@@ -299,7 +307,11 @@ mod tests {
         let ctx = test_ctx().await;
 
         let output = tool
-            .execute(&ctx, r#"{"command":"sleep 0.1","background":true}"#, "sess-1")
+            .execute(
+                &ctx,
+                r#"{"command":"sleep 0.1","background":true}"#,
+                "sess-1",
+            )
             .await
             .expect("background exec should succeed");
         let parsed: Value = serde_json::from_str(&output).expect("exec output should be json");
@@ -309,6 +321,10 @@ mod tests {
             .as_str()
             .expect("backgrounded response should include session id");
         let sessions = ctx.process_manager.list().await;
-        assert!(sessions.iter().any(|snapshot| snapshot.session_id == session_id));
+        assert!(
+            sessions
+                .iter()
+                .any(|snapshot| snapshot.session_id == session_id)
+        );
     }
 }

--- a/src/tools/builtin/web_fetch.rs
+++ b/src/tools/builtin/web_fetch.rs
@@ -163,8 +163,9 @@ mod tests {
 
     #[test]
     fn fetch_returns_plain_text_body_when_not_html() {
-        let output = render_fetch_response("http://example.test", 200, "plain body from server", 100)
-            .expect("plain text response should render");
+        let output =
+            render_fetch_response("http://example.test", 200, "plain body from server", 100)
+                .expect("plain text response should render");
 
         assert_eq!(output, "plain body from server");
     }

--- a/tests/gateway_roundtrip_e2e.rs
+++ b/tests/gateway_roundtrip_e2e.rs
@@ -4,6 +4,14 @@ use simpleclaw::testing::{
     ProviderScriptStep, ScriptedToolCall, TestAgentConfig, TestHarnessConfig,
     run_single_gateway_roundtrip,
 };
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+fn exec_test_guard() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 fn session_rows(db_path: &std::path::Path, session_id: &str) -> Vec<(String, String)> {
     let conn = Connection::open(db_path).expect("short-term sqlite db should be readable");
@@ -198,6 +206,7 @@ async fn gateway_listener_roundtrip_routes_context_only_when_mention_missing() {
 
 #[tokio::test]
 async fn gateway_roundtrip_exec_tool_call_returns_pwd_output() {
+    let _guard = exec_test_guard();
     let config = TestHarnessConfig {
         inbound_content: "run pwd".to_owned(),
         mock_reply: "tool-finished".to_owned(),
@@ -236,6 +245,7 @@ async fn gateway_roundtrip_exec_tool_call_returns_pwd_output() {
 
 #[tokio::test]
 async fn gateway_roundtrip_exec_tool_call_reports_timeout_error() {
+    let _guard = exec_test_guard();
     let config = TestHarnessConfig {
         inbound_content: "run slow command".to_owned(),
         mock_reply: "timeout-finished".to_owned(),
@@ -272,6 +282,7 @@ async fn gateway_roundtrip_exec_tool_call_reports_timeout_error() {
 
 #[tokio::test]
 async fn gateway_roundtrip_exec_tool_call_returns_pwd_output_on_repeated_runs() {
+    let _guard = exec_test_guard();
     for _ in 0..2 {
         let config = TestHarnessConfig {
             inbound_content: "run pwd".to_owned(),
@@ -313,7 +324,9 @@ async fn gateway_listener_roundtrip_sends_safe_error_reply_when_provider_fails()
             "default",
             "Default",
             "default",
-            vec![ProviderScriptStep::Error("mock provider failure".to_owned())],
+            vec![ProviderScriptStep::Error(
+                "mock provider failure".to_owned(),
+            )],
         )],
         ..TestHarnessConfig::default()
     };
@@ -386,24 +399,27 @@ async fn gateway_listener_roundtrip_invokes_dm_without_requiring_mention() {
 
 #[tokio::test]
 async fn gateway_roundtrip_processes_background_completion_followup() {
+    let _guard = exec_test_guard();
     let config = TestHarnessConfig {
         additional_inbounds_to_process: 1,
         additional_inbound_timeout_ms: 4_000,
-        agents: vec![TestAgentConfig::new(
-            "default",
-            "Default",
-            "default",
-            vec![
-                ProviderScriptStep::ToolCall(ScriptedToolCall {
-                    id: Some("call-exec-background".to_owned()),
-                    name: "exec".to_owned(),
-                    args_json: r#"{"command":"sleep 0.2","background":true}"#.to_owned(),
-                }),
-                ProviderScriptStep::Reply("waiting for background".to_owned()),
-                ProviderScriptStep::Reply("background complete".to_owned()),
-            ],
-        )
-        .with_exec_tool(None, true, false)],
+        agents: vec![
+            TestAgentConfig::new(
+                "default",
+                "Default",
+                "default",
+                vec![
+                    ProviderScriptStep::ToolCall(ScriptedToolCall {
+                        id: Some("call-exec-background".to_owned()),
+                        name: "exec".to_owned(),
+                        args_json: r#"{"command":"sleep 0.2","background":true}"#.to_owned(),
+                    }),
+                    ProviderScriptStep::Reply("waiting for background".to_owned()),
+                    ProviderScriptStep::Reply("background complete".to_owned()),
+                ],
+            )
+            .with_exec_tool(None, true, false),
+        ],
         ..TestHarnessConfig::default()
     };
     let result = run_single_gateway_roundtrip(config)
@@ -412,7 +428,10 @@ async fn gateway_roundtrip_processes_background_completion_followup() {
 
     assert_eq!(result.provider_call_count, 3);
     assert_eq!(result.outbound_messages.len(), 2);
-    assert_eq!(result.outbound_messages[0].content, "waiting for background");
+    assert_eq!(
+        result.outbound_messages[0].content,
+        "waiting for background"
+    );
     assert_eq!(result.outbound_messages[1].content, "background complete");
     let response = result
         .observed_tool_response
@@ -421,7 +440,10 @@ async fn gateway_roundtrip_processes_background_completion_followup() {
     let nested = response["content"]
         .as_str()
         .expect("tool response content should be a string");
-    assert!(nested.contains("\"status\":\"backgrounded\""), "nested={nested}");
+    assert!(
+        nested.contains("\"status\":\"backgrounded\""),
+        "nested={nested}"
+    );
 }
 
 #[tokio::test]
@@ -466,27 +488,32 @@ async fn gateway_roundtrip_summon_tool_invokes_second_agent() {
         .observed_tool_response
         .expect("summon tool response should be captured");
     assert_eq!(response["status"], Value::String("ok".to_owned()));
-    assert_eq!(response["content"], Value::String("helper result".to_owned()));
+    assert_eq!(
+        response["content"],
+        Value::String("helper result".to_owned())
+    );
 }
 
 #[tokio::test]
 async fn gateway_roundtrip_task_tool_invokes_worker_flow() {
     let config = TestHarnessConfig {
-        agents: vec![TestAgentConfig::new(
-            "default",
-            "Default",
-            "default",
-            vec![
-                ProviderScriptStep::ToolCall(ScriptedToolCall {
-                    id: Some("call-task-worker".to_owned()),
-                    name: "task".to_owned(),
-                    args_json: r#"{"prompt":"do delegated work"}"#.to_owned(),
-                }),
-                ProviderScriptStep::Reply("worker result".to_owned()),
-                ProviderScriptStep::Reply("task wrapped up".to_owned()),
-            ],
-        )
-        .with_task_worker_max_steps(Some(2))],
+        agents: vec![
+            TestAgentConfig::new(
+                "default",
+                "Default",
+                "default",
+                vec![
+                    ProviderScriptStep::ToolCall(ScriptedToolCall {
+                        id: Some("call-task-worker".to_owned()),
+                        name: "task".to_owned(),
+                        args_json: r#"{"prompt":"do delegated work"}"#.to_owned(),
+                    }),
+                    ProviderScriptStep::Reply("worker result".to_owned()),
+                    ProviderScriptStep::Reply("task wrapped up".to_owned()),
+                ],
+            )
+            .with_task_worker_max_steps(Some(2)),
+        ],
         ..TestHarnessConfig::default()
     };
     let result = run_single_gateway_roundtrip(config)
@@ -500,5 +527,8 @@ async fn gateway_roundtrip_task_tool_invokes_worker_flow() {
         .observed_tool_response
         .expect("task tool response should be captured");
     assert_eq!(response["status"], Value::String("ok".to_owned()));
-    assert_eq!(response["content"], Value::String("worker result".to_owned()));
+    assert_eq!(
+        response["content"],
+        Value::String("worker result".to_owned())
+    );
 }


### PR DESCRIPTION
## Summary
- add provider streaming support and progressive editable-message updates
- make channel edit capability explicit and avoid duplicate fallback sends on non-editable transports
- add  to control whether a channel uses progressive streaming replies

## Testing
- cargo test config::tests
- cargo test run::tests
- cargo test providers::gemini::tests

## Notes
- full 
running 247 tests
test agent::tests::inject_caller_context_marks_scheduled_cron_trigger ... ok
test agent::tests::format_recalled_memory_caps_output_by_char_limit ... ok
test agent::tests::inject_caller_context_adds_environment_and_speaker ... ok
test channels::discord::tests::parse_reaction_type_custom_emoji_keeps_identity ... ok
test channels::policy::tests::accepts_when_mentions_required_and_present ... ok
test channels::policy::tests::rejects_when_mentions_required_but_missing ... ok
test channels::policy::tests::rejects_disallowed_user ... ok
test channels::policy::tests::dm_ignores_mentions_requirement ... ok
test channels::policy::tests::rejects_disallowed_dm_user ... ok
test channels::policy::tests::channel_override_takes_precedence ... ok
test cli::tests::rejects_missing_required_flags ... ok
test cli::tests::rejects_invalid_memory_mode ... ok
test cli::tests::rejects_non_positive_limit ... ok
test config::execution::tests::merge_with_overrides_applies_only_provided_fields ... ok
test config::execution::tests::merge_with_overrides_returns_defaults_when_empty ... ok
test cli::tests::parses_agent_memory_short ... ok
test cli::tests::parses_agent_memory_long ... ok
test cli::tests::parses_agent_memory_both ... ok
test channels::discord::tests::collect_bot_reactions_includes_only_current_user_reactions ... ok
test config::tests::agent_config_defaults_tools_skills_config ... ok
test config::tests::agent_config_rejects_legacy_read_allow_all_field ... ok
test config::tests::agent_config_rejects_legacy_sandbox_field ... ok
test config::tests::agent_config_rejects_legacy_name_field ... ok
test config::tests::agent_config_rejects_legacy_network_allow_all_field ... ok
test config::tests::agent_config_rejects_legacy_routing_field ... ok
test config::tests::channel_config_defaults_to_streaming_output ... ok
test config::tests::channel_config_accepts_streaming_output ... ok
test config::tests::channel_config_accepts_normal_output ... ok
test config::tests::agent_config_rejects_legacy_skills_field ... ok
test config::tests::channel_config_rejects_unknown_output ... ok
test config::tests::channel_policy_overrides_server_and_global ... ok
test config::tests::agent_config_supports_typed_tool_map ... ok
test config::tests::dm_scope_overrides_defaults_and_forces_mentions_off ... ok
test config::tests::execution_defaults_history_window ... ok
test config::tests::execution_config_rejects_legacy_workspace_fields ... ok
test config::tests::execution_config_rejects_exec_policy_fields_moved_to_agent_config ... ok
test config::tests::dm_override_applies_after_channel_defaults ... ok
test config::tests::execution_defaults_memory_recall_rejects_unknown_fields ... ok
test config::tests::execution_defaults_tool_call_transparency_defaults_off ... ok
test config::tests::execution_defaults_rejects_legacy_memory_preinject_key ... ok
test config::tests::execution_defaults_tool_call_transparency_accepts_values ... ok
test config::tests::execution_defaults_memory_recall_rejects_legacy_short_term_weight ... ok
test config::tests::execution_defaults_tool_call_transparency_rejects_unknown_value ... ok
test config::tests::execution_log_level_accepts_debug ... ok
test config::tests::execution_defaults_memory_recall_accepts_overrides ... ok
test config::tests::execution_log_level_rejects_unknown_value ... ok
test config::tests::global_defaults_apply_when_no_workspace_or_channel_match ... ok
test config::tests::no_allow_from_defaults_to_allow_all ... ok
test config::tests::global_config_rejects_plaintext_secret_values ... ok
test config::tests::global_config_allows_missing_optional_secret_fields ... ok
test config::tests::global_config_resolves_required_secret_references ... ok
test config::tests::global_config_rejects_plaintext_web_search_api_key ... ok
test config::tests::normalize_workspace_path_expands_dollar_env_syntax ... ok
test config::tests::normalize_agents_workspace_paths_updates_entries ... ok
test config::tests::rejects_legacy_discord_token_env_field ... ok
test config::tests::rejects_legacy_provider_api_key_env_field ... ok
test config::tests::rejects_unknown_gateway_channel_kind ... ok
test config::tests::runtime_memory_recall_normalized_clamps_values ... ok
test config::tests::rejects_unknown_provider_kind ... ok
test agent::tests::agent_runtime_skips_assistant_persist_for_no_reply_and_reports_memory_recall_hits ... ok
test agent::tests::agent_runtime_persists_user_and_assistant_messages_and_seeds_history ... ok
test config::tests::tools_config_defaults_enable_all_builtin_tools ... ok
test config::tests::tools_config_rejects_legacy_enabled_tools_allowlist ... ok
test config::tests::normalize_workspace_path_expands_home_prefix ... ok
test config::tests::reconcile_routing_default_agent_does_not_override_when_legacy_default_exists ... ok
test config::tests::validate_agents_config_rejects_brave_without_api_key_when_enabled ... ok
test config::tests::reconcile_routing_default_agent_uses_agents_default_when_legacy_default_missing ... ok
test config::tests::validate_agents_config_rejects_duplicate_ids ... ok
test config::tests::workspace_policy_applies_when_channel_missing ... ok
test config::tests::validate_agents_config_rejects_duckduckgo_with_api_key ... ok
test config::tests::validate_agents_config_rejects_zero_memory_top_k ... ok
test config::tests::validate_agents_config_rejects_zero_web_fetch_max_chars ... ok
test config::tests::validate_agents_config_rejects_zero_tool_timeout ... ok
test dispatch::tests::native_parse_response_empty ... ok
test dispatch::tests::native_parse_response_final_text ... ok
test dispatch::tests::owner_restricted_flag_allows_owner ... ok
test config::tests::validate_agents_config_rejects_missing_default_id ... ok
test dispatch::tests::owner_restricted_flag_denies_non_owner ... ok
test dispatch::tests::restricted_tool_allows_owner ... ok
test dispatch::tests::restricted_tool_rejects_empty_owner_ids ... ok
test dispatch::tests::restricted_tool_rejects_non_owner ... ok
test dispatch::tests::should_send_tool_specs_native_true_xml_false ... ok
test dispatch::tests::unrestricted_tool_ignores_owner_rules ... ok
test dispatch::tests::xml_format_for_history ... ok
test dispatch::tests::native_parse_response_tool_calls ... ok
test dispatch::tests::native_format_for_history ... ok
test dispatch::tests::native_format_for_history_error_case ... ok
test dispatch::tests::xml_prompt_instructions_contains_tool_info ... ok
test gateway::router::tests::route_inbound_drops_dm_when_policy_denies_ingest ... ok
test gateway::router::tests::route_inbound_sets_policy_and_session_fields ... ok
test gateway::session::tests::dm_session_key_uses_main_suffix ... ok
test gateway::session::tests::non_dm_session_key_uses_discord_channel ... ok
test gateway::tests::gateway_assigns_source_channel_and_session_key ... ok
test invoke::tests::invoke_agent_returns_missing_memory_error ... ok
test invoke::tests::invoke_agent_returns_unknown_agent_error ... ok
test dispatch::tests::xml_parse_malformed_skipped ... ok
test dispatch::tests::xml_parse_response_no_tags ... ok
test dispatch::tests::xml_parse_response_with_tags ... ok
test dispatch::tests::xml_parse_empty_arguments ... ok
test dispatch::tests::xml_multiline_arguments ... ok
test invoke::tests::invoke_worker_disables_recursive_tools_in_tool_specs ... ok
test memory::recall::tests::normalize_memory_kind_accepts_only_canonical_values ... ok
test invoke::tests::invoke_worker_uses_max_steps_override ... ok
test invoke::tests::invoke_agent_runs_with_target_agent_prompt_and_history ... ok
test dispatch::tests::xml_parse_single_tool_call ... ok
test dispatch::tests::xml_parse_multiple_tool_calls ... ok
test memory::recall::tests::parse_memory_kind_returns_error_for_unknown_values ... ok
test paths::tests::resolve_has_expected_layout ... ok
test providers::gemini::tests::encodes_tool_function_response_part ... ok
test providers::gemini::tests::encodes_assistant_function_call_part ... ok
test providers::gemini::tests::preserves_plain_text_messages ... ok
test memory::recall::tests::rank_recall_hits_filters_on_raw_similarity_not_final_score ... ok
test providers::gemini::tests::preview_text_truncates_by_character_count ... ok
test memory::recall::tests::rank_recall_hits_applies_threshold_dedupe_and_limit ... ok
test prompt::tests::inspect_workspace_reports_presence_and_sizes ... ok
test providers::gemini::tests::parses_provider_response_text_and_tool_calls ... ok
test prompt::tests::skips_missing_prompt_layers ... ok
test providers::gemini::tests::summarizes_json_error_body ... ok
test providers::gemini::tests::summarizes_plain_text_error_body ... ok
test providers::types::tests::provider_response_to_stream_emits_text_tool_calls_and_done ... ok
test react::tests::generate_provider_response_returns_stream_errors ... ok
test providers::gemini::tests::stream_accumulator_preserves_duplicate_idless_tool_calls ... ok
test react::tests::generate_provider_response_streams_accumulated_text_and_tool_calls ... ok
test providers::gemini::tests::stream_accumulator_handles_split_frames_and_buffers_tool_calls_until_finish ... ok
test providers::gemini::tests::stream_accumulator_reports_invalid_json ... ok
test react::tests::sanitize_log_preview_flattens_newlines ... ok
test react::tests::sanitize_log_preview_redacts_json_secret_keys ... ok
test react::tests::sanitize_log_preview_truncates_long_output ... ok
test react::tests::sanitize_log_preview_redacts_plaintext_secret_patterns ... ok
test reply_policy::tests::does_not_match_different_case ... ok
test reply_policy::tests::does_not_match_other_text ... ok
test reply_policy::tests::matches_exact_sentinel ... ok
test reply_policy::tests::matches_trimmed_sentinel ... ok
test run::composition::tests::agent_workspace_memory_paths_uses_simpleclaw_memory_layout ... ok
test react::tests::tool_status_reports_unknown_tool_name ... ok
test react::tests::tool_definitions_only_include_enabled_tools ... ok
test run::composition::tests::assemble_runtime_state_rejects_missing_provider_registration ... ok
test run::composition::tests::assemble_runtime_state_rejects_empty_provider_key ... ok
test run::cron_scheduler::tests::should_fire_when_interval_elapsed_since_last_fired ... ok
test run::cron_scheduler::tests::should_fire_without_last_fired_when_schedule_matches_current_minute ... ok
test run::cron_scheduler::tests::should_not_fire_when_already_fired_this_minute ... ok
test run::session::tests::session_workers_run_different_keys_concurrently ... ok
test memory::tests::long_term_duplicate_check_matches_recent_identical_fact ... ok
test run::tests::dispatch_inbound_continues_when_seen_reaction_fails ... ok
test run::tests::dispatch_inbound_adds_seen_reaction_for_invoke_messages ... ok
test run::tests::dispatch_inbound_skips_seen_reaction_for_passive_messages ... ok
test run::tests::dispatch_inbound_skips_seen_reaction_for_system_messages ... ok
test memory::tests::recent_short_term_ids_returns_newest_user_and_assistant_only ... ok
test run::composition::tests::assemble_runtime_state_builds_runtime_directory_and_safe_reply ... ok
test run::tests::handle_inbound_once_sends_config_error_for_unknown_agent ... ok
test run::tests::handle_inbound_once_records_passive_context_without_outbound_reply ... ok
test run::logging::tests::collect_log_history_orders_days_then_active ... ok
test run::logging::tests::prune_daily_logs_keeps_latest_two_days ... ok
test run::tests::handle_inbound_once_uses_single_final_send_when_output_mode_is_normal ... ok
test run::tests::handle_inbound_once_uses_single_final_send_for_non_editable_channels ... ok
test run::tests::handle_inbound_once_continues_after_typing_failure_and_sends_reply ... ok
test run::tests::long_memory_returns_newest_first_with_limit ... ok
test run::tests::handle_inbound_once_swallows_channel_send_failure_after_successful_run ... ok
test run::tests::handle_inbound_once_sends_safe_reply_when_runtime_fails ... ok
test run::transparency::tests::deep_nesting_is_counted_in_flattened_grouping ... ok
test run::transparency::tests::discord_subtext_escapes_underscores ... ok
test run::transparency::tests::enabled_mode_renders_grouped_status_chips ... ok
test run::transparency::tests::enabled_mode_with_no_calls_returns_reply_unchanged ... ok
test run::transparency::tests::grouped_summary_preserves_first_seen_tool_order ... ok
test run::transparency::tests::memory_recall_line_can_render_with_tool_summary ... ok
test run::transparency::tests::memory_recall_transparency_omits_line_when_not_used ... ok
test run::transparency::tests::memory_recall_transparency_renders_used_with_hits ... ok
test run::transparency::tests::nested_calls_are_included_in_grouped_summary ... ok
test run::transparency::tests::off_mode_returns_reply_unchanged ... ok
test run::transparency::tests::plain_footer_style_is_available_for_channel_fallbacks ... ok
test run::transparency::tests::repeated_calls_are_aggregated_with_ok_and_err_counts ... ok
test secrets::tests::parse_secret_reference_accepts_valid_pattern ... ok
test run::tests::short_memory_returns_newest_first_with_limit ... ok
test secrets::tests::parse_secret_reference_rejects_plaintext ... ok
test secrets::tests::parse_secret_reference_rejects_invalid_name ... ok
test secrets::tests::resolver_errors_when_missing_everywhere ... ok
test secrets::tests::resolver_prefers_env_over_file ... ok
test secrets::tests::resolver_reads_file_when_env_missing ... ok
test tools::builtin::common::tests::parse_exec_args_accepts_background_flag ... ok
test tools::builtin::common::tests::parse_forget_args_accepts_defaults_and_camel_case ... ok
test tools::builtin::common::tests::parse_forget_args_clamps_threshold_and_max ... ok
test tools::builtin::common::tests::parse_process_args_accepts_session_id_camel_case ... ok
test tools::builtin::common::tests::parse_task_args_accepts_prompt_object ... ok
test run::tests::handle_inbound_once_uses_streaming_message_send_and_final_edit ... ok
test tools::builtin::cron::store::tests::update_last_fired_persists_timestamp ... ok
test tools::builtin::cron::tests::input_schema_avoids_conditional_keywords ... ok
test tools::builtin::cron::store::tests::open_create_list_delete_and_count ... ok
test tools::builtin::edit::tests::create_dry_run_does_not_write_file ... ok
test tools::builtin::edit::tests::replace_requires_replace_all_when_ambiguous ... ok
test tools::builtin::edit::tests::create_and_replace_roundtrip ... ok
test tools::builtin::edit::tests::dry_run_does_not_mutate_file ... ok
test tools::builtin::edit::tests::sandbox_denies_outside_workspace_path ... ok
test tools::builtin::exec::tests::exec_rejects_empty_command ... ok
test tools::builtin::exec::tests::exec_rejects_background_when_disabled ... ok
test tools::builtin::memory::tests::parse_store_scope_accepts_all_known_values ... ok
test tools::builtin::memory::tests::parse_store_scope_defaults_to_combined ... ok
test tools::builtin::memory::tests::resolve_top_k_clamps_to_max ... ok
test tools::builtin::memory::tests::resolve_top_k_rejects_zero_after_clamp ... ok
test tools::builtin::memory::tests::resolve_top_k_uses_default_when_missing ... ok
test tools::builtin::read::tests::host_path_maps_to_workspace_guest_path ... ok
test tools::builtin::read::tests::resolve_path_expands_environment_variable ... ok
test tools::builtin::read::tests::resolve_path_expands_home_prefix ... ok
test tools::builtin::read::tests::resolve_path_in_wasm_sandbox_allows_extra_readable_path ... ok
test tools::builtin::exec::tests::exec_backgrounds_process_when_enabled ... ok
test tools::builtin::read::tests::resolve_path_in_wasm_sandbox_allows_relative_workspace_file ... ok
test tools::builtin::read::tests::resolve_path_in_wasm_sandbox_denies_absolute_outside_workspace ... ok
test tools::builtin::read::tests::resolve_path_with_sandbox_off_allows_absolute_outside_workspace ... ok
test tools::builtin::read::tests::resolve_path_in_wasm_sandbox_denies_parent_traversal_escape ... ok
test tools::builtin::summon::tests::empty_allowlist_denies_any_target ... ok
test tools::builtin::summon::tests::non_empty_allowlist_restricts_target ... ok
test tools::builtin::web_fetch::tests::fetch_rejects_empty_url ... ok
test tools::builtin::web_fetch::tests::fetch_reports_non_success_status ... ok
test tools::builtin::web_fetch::tests::fetch_returns_plain_text_body_when_not_html ... ok
test tools::builtin::web_search::tests::map_brave_results_keeps_url_and_age ... ok
test tools::builtin::web_search::tests::map_duckduckgo_falls_back_to_related_topics ... ok
test tools::builtin::web_search::tests::map_duckduckgo_prefers_abstract_text ... ok
test tools::builtin::web_search::tests::map_duckduckgo_uses_results_when_abstract_missing ... ok
test tools::builtin::web_search::tests::parse_duckduckgo_text_splits_title_description ... ok
test tools::builtin::web_search::tests::push_result_skips_duplicates ... ok
test tools::builtin::web_fetch::tests::fetch_extracts_html_body_text_and_truncates ... ok
test tools::sandbox::tests::resolve_guest_artifact_path_errors_for_missing_module ... ok
test tools::sandbox_runtime::tests::build_runtime_config_allows_network_when_enabled ... ok
test tools::sandbox_runtime::tests::build_runtime_config_disables_network_by_default ... ok
test tools::sandbox_runtime::tests::build_write_allow_paths_includes_workspace_tmp_and_extra ... ok
test tools::skill::tests::agent_scope_overrides_global_scope ... ok
test tools::sandbox::tests::execute_tool_proxies_calls ... ok
test tools::skill::tests::extract_description_fallback_missing_field ... ok
test tools::skill::tests::disables_discovered_skills ... ok
test tools::skill::tests::extract_description_fallback_no_frontmatter ... ok
test tools::skill::tests::extract_description_from_frontmatter ... ok
test tools::skill::tests::extract_description_from_quoted_frontmatter ... ok
test tools::skill::tests::rejects_invalid_disabled_skill_id ... ok
test tools::tests::active_tools_without_removes_target_tool ... ok
test tools::skill::tests::skips_missing_and_empty_skills ... ok
test tools::tests::register_overwrites_existing_tool_by_name ... ok
test tools::tests::resolve_active_marks_skill_tools_unrestricted ... ok
test tools::tests::resolve_active_uses_owner_restricted_flag_from_config ... ok
test tools::tests::tool_ctx_owner_allowed_when_owner_ids_empty_is_false ... ok
test tools::tests::tool_ctx_owner_allowed_when_user_matches ... ok
test tools::tests::tool_ctx_owner_allowed_when_user_missing ... ok
test run::tests::streaming_display_rate_limits_edit_spawns ... ok
test tools::builtin::exec::tests::exec_runs_foreground_command_without_sandbox ... ok
test run::session::tests::session_worker_expires_when_idle_and_respawns ... ok
test run::session::tests::session_workers_serialize_messages_for_same_key ... ok
test tools::tests::completion_watcher_marks_background_process_complete_without_route ... ok
test run::tests::handle_inbound_once_waits_for_slow_initial_stream_send_without_duplicate_fallback ... ok
test run::tests::handle_inbound_once_finalizes_after_in_flight_edit_without_duplicate_send ... ok

test result: ok. 247 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.34s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 13 tests
test gateway_listener_roundtrip_routes_context_only_when_mention_missing ... ok
test gateway_listener_roundtrip_invokes_dm_without_requiring_mention ... ok
test gateway_listener_roundtrip_routes_and_processes_invoke_message ... ok
test gateway_roundtrip_summon_tool_invokes_second_agent ... ok
test gateway_roundtrip_suppresses_no_reply_and_skips_assistant_persist ... ok
test gateway_listener_roundtrip_sends_safe_error_reply_when_provider_fails ... ok
test gateway_roundtrip_task_tool_invokes_worker_flow ... ok
test gateway_roundtrip_uses_mock_provider_and_persists_ephemeral_sqlite ... ok
test gateway_roundtrip_exec_tool_call_returns_pwd_output ... ok
test gateway_roundtrip_exec_tool_call_returns_pwd_output_on_repeated_runs ... ok
test gateway_listener_roundtrip_drops_disallowed_user_before_runtime ... ok
test gateway_roundtrip_exec_tool_call_reports_timeout_error ... ok
test gateway_roundtrip_processes_background_completion_followup ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.53s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s in this environment still hits the known sandbox restriction in the exec e2e tests