### PR TITLE
fix(memory): clarify recall prompt and transparency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,4 @@
 7. Prefer explicit interfaces at module boundaries; hide concrete types behind traits/type aliases where it improves substitution.
 8. Prefer composition over inheritance-style abstractions; keep abstractions shallow and purposeful.
 9. Require observability for important flows: structured logs, clear error context, and stable event names.
+10. Do not normalize code smells with blanket suppressions such as `#[allow(unused)]`, `#[allow(dead_code)]`, or similar exceptions unless they are genuinely necessary and narrowly scoped with a clear reason.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ sequenceDiagram
 ### 3) Prompt construction per turn
 - Base prompt: concatenated workspace files in this order:
   - `IDENTITY.md`, `AGENT.md`, `USER.md`, `MEMORY.md`, `SOUL.md`
-- Optional memory recall appends a scored long-term context section.
+- Optional memory recall appends combined semantic memory context: long-term facts plus older same-session short-term messages outside the recent `history_messages` window.
 - Caller context is always injected (`CURRENT SPEAKER` with user id/name).
 
 ### 4) Tool execution security controls

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -189,8 +189,10 @@ impl AgentRuntime {
                 return Err(err);
             }
         };
-        outcome.memory_recall_used = prompt_build.memory_recall_hits > 0;
-        outcome.memory_recall_hits = prompt_build.memory_recall_hits;
+        outcome.memory_recall_used =
+            prompt_build.memory_recall_short_hits + prompt_build.memory_recall_long_hits > 0;
+        outcome.memory_recall_short_hits = prompt_build.memory_recall_short_hits;
+        outcome.memory_recall_long_hits = prompt_build.memory_recall_long_hits;
 
         if !is_no_reply(&outcome.reply) {
             memory
@@ -308,46 +310,44 @@ impl AgentRuntime {
 
         debug!(status = "completed", "memory recall");
 
-        let section = format_recalled_memory(&hits, config.max_chars as usize);
-        if section.is_empty() {
+        let recalled = format_recalled_memory(&hits, config.max_chars as usize);
+        if recalled.section.is_empty() {
             return PromptBuild::without_recall(self.config.system_prompt.clone());
         }
 
         PromptBuild {
-            system_prompt: format!("{}\n\n{}", self.config.system_prompt, section),
-            memory_recall_hits: count_formatted_recalled_hits(&section),
+            system_prompt: format!("{}\n\n{}", self.config.system_prompt, recalled.section),
+            memory_recall_short_hits: recalled.short_hits,
+            memory_recall_long_hits: recalled.long_hits,
         }
     }
 }
 
 struct PromptBuild {
     system_prompt: String,
-    memory_recall_hits: usize,
+    memory_recall_short_hits: usize,
+    memory_recall_long_hits: usize,
 }
 
 impl PromptBuild {
     fn without_recall(system_prompt: String) -> Self {
         Self {
             system_prompt,
-            memory_recall_hits: 0,
+            memory_recall_short_hits: 0,
+            memory_recall_long_hits: 0,
         }
     }
 }
 
-fn count_formatted_recalled_hits(section: &str) -> usize {
-    section
-        .lines()
-        .filter(|line| line.starts_with(char::is_numeric))
-        .count()
-}
-
-fn format_recalled_memory(hits: &[MemoryRecallHit], max_chars: usize) -> String {
+fn format_recalled_memory(hits: &[MemoryRecallHit], max_chars: usize) -> PromptBuildMemorySection {
     if hits.is_empty() || max_chars == 0 {
-        return String::new();
+        return PromptBuildMemorySection::default();
     }
 
-    let base = "# POTENTIALLY RELEVANT LONG-TERM MEMORY\nUse this as optional background context. It may be stale or incomplete; prioritize the current user message and conversation.";
+    let base = "# POTENTIALLY RELEVANT MEMORY\nUse this as optional background context. It may be stale or incomplete; prioritize the current user message and conversation.";
     let mut section = base.to_owned();
+    let mut short_hits = 0;
+    let mut long_hits = 0;
     for (index, hit) in hits.iter().enumerate() {
         let line = format!(
             "\n{}. [{}] {}",
@@ -359,13 +359,28 @@ fn format_recalled_memory(hits: &[MemoryRecallHit], max_chars: usize) -> String 
             break;
         }
         section.push_str(&line);
+        match hit.store {
+            MemoryHitStore::LongTerm => long_hits += 1,
+            MemoryHitStore::ShortTerm => short_hits += 1,
+        }
     }
 
     if section == base {
-        String::new()
+        PromptBuildMemorySection::default()
     } else {
-        section
+        PromptBuildMemorySection {
+            section,
+            short_hits,
+            long_hits,
+        }
     }
+}
+
+#[derive(Default)]
+struct PromptBuildMemorySection {
+    section: String,
+    short_hits: usize,
+    long_hits: usize,
 }
 
 fn memory_hit_label(hit: &MemoryRecallHit) -> String {
@@ -769,14 +784,16 @@ mod tests {
         ];
 
         let section = format_recalled_memory(&hits, 280);
-        assert!(section.starts_with("# POTENTIALLY RELEVANT LONG-TERM MEMORY"));
-        assert!(section.contains("optional background context"));
-        assert!(section.contains("1. [long-term/prefs]"));
-        assert!(!section.contains("score="));
+        assert!(section.section.starts_with("# POTENTIALLY RELEVANT MEMORY"));
+        assert!(section.section.contains("optional background context"));
+        assert!(section.section.contains("1. [long-term/prefs]"));
+        assert!(!section.section.contains("score="));
         assert!(
-            section.contains("2."),
+            section.section.contains("2."),
             "both items should fit without score metadata"
         );
+        assert_eq!(section.short_hits, 0);
+        assert_eq!(section.long_hits, 2);
     }
 
     #[test]
@@ -890,14 +907,15 @@ mod tests {
 
         assert_eq!(outcome.reply, "NO_REPLY");
         assert!(outcome.memory_recall_used);
-        assert_eq!(outcome.memory_recall_hits, 1);
+        assert_eq!(outcome.memory_recall_short_hits, 0);
+        assert_eq!(outcome.memory_recall_long_hits, 1);
 
         let appended = memory_impl.appended().await;
         assert_eq!(appended.len(), 1);
         assert_eq!(appended[0].1, StoredRole::User);
 
         let prompts = provider_impl.system_prompts().await;
-        assert!(prompts[0].contains("# POTENTIALLY RELEVANT LONG-TERM MEMORY"));
+        assert!(prompts[0].contains("# POTENTIALLY RELEVANT MEMORY"));
         assert!(prompts[0].contains("Prefers short answers"));
     }
 }

--- a/src/react.rs
+++ b/src/react.rs
@@ -51,7 +51,8 @@ pub struct RunOutcome {
     pub reply: String,
     pub tool_calls: Vec<ToolExecutionResult>,
     pub memory_recall_used: bool,
-    pub memory_recall_hits: usize,
+    pub memory_recall_short_hits: usize,
+    pub memory_recall_long_hits: usize,
 }
 
 impl ReactLoop {
@@ -206,7 +207,8 @@ async fn run_loop(
                     reply: text,
                     tool_calls: executed_tool_calls,
                     memory_recall_used: false,
-                    memory_recall_hits: 0,
+                    memory_recall_short_hits: 0,
+                    memory_recall_long_hits: 0,
                 });
             }
             DispatchAction::Empty => {
@@ -225,7 +227,8 @@ async fn run_loop(
         reply: "max_steps reached without final response".to_owned(),
         tool_calls: executed_tool_calls,
         memory_recall_used: false,
-        memory_recall_hits: 0,
+        memory_recall_short_hits: 0,
+        memory_recall_long_hits: 0,
     })
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -526,7 +526,8 @@ pub(crate) async fn handle_inbound_once(
                 transparency.tool_calls,
                 transparency.memory_recall,
                 outcome.memory_recall_used,
-                outcome.memory_recall_hits,
+                outcome.memory_recall_short_hits,
+                outcome.memory_recall_long_hits,
                 inbound.source_channel,
             );
             let send_result = if let Some(streaming_display) = streaming_display.as_ref() {

--- a/src/run/transparency.rs
+++ b/src/run/transparency.rs
@@ -9,7 +9,8 @@ pub(super) fn render_tool_call_transparency(
     tool_calls_enabled: bool,
     memory_recall_enabled: bool,
     memory_recall_used: bool,
-    memory_recall_hits: usize,
+    memory_recall_short_hits: usize,
+    memory_recall_long_hits: usize,
     channel_kind: GatewayChannelKind,
 ) -> String {
     let summary = transparency_summary(
@@ -17,7 +18,8 @@ pub(super) fn render_tool_call_transparency(
         tool_calls_enabled,
         memory_recall_enabled,
         memory_recall_used,
-        memory_recall_hits,
+        memory_recall_short_hits,
+        memory_recall_long_hits,
     );
     if summary.is_empty() {
         return reply.to_owned();
@@ -42,13 +44,19 @@ fn style_for_channel(kind: GatewayChannelKind) -> Option<TransparencyRenderStyle
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct TransparencySummary {
     tool_groups: Vec<ToolSummaryGroup>,
-    memory_hits: Option<usize>,
+    memory_hits: Option<MemoryTransparencySummary>,
 }
 
 impl TransparencySummary {
     fn is_empty(&self) -> bool {
         self.tool_groups.is_empty() && self.memory_hits.is_none()
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MemoryTransparencySummary {
+    short_hits: usize,
+    long_hits: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,14 +71,18 @@ fn transparency_summary(
     tool_calls_enabled: bool,
     memory_recall_enabled: bool,
     memory_recall_used: bool,
-    memory_recall_hits: usize,
+    memory_recall_short_hits: usize,
+    memory_recall_long_hits: usize,
 ) -> TransparencySummary {
     let mut summary = TransparencySummary::default();
     if tool_calls_enabled && !tool_calls.is_empty() {
         summary.tool_groups = tool_summary_groups(tool_calls);
     }
     if memory_recall_enabled && memory_recall_used {
-        summary.memory_hits = Some(memory_recall_hits);
+        summary.memory_hits = Some(MemoryTransparencySummary {
+            short_hits: memory_recall_short_hits,
+            long_hits: memory_recall_long_hits,
+        });
     }
     summary
 }
@@ -176,7 +188,10 @@ fn render_for_style(
                 parts.push(format_tool_summary_plain(&summary.tool_groups));
             }
             if let Some(hits) = summary.memory_hits {
-                parts.push(format!("memory: hits={hits}"));
+                parts.push(format!(
+                    "recall: short={} long={}",
+                    hits.short_hits, hits.long_hits
+                ));
             }
             format!("{reply}\n---\n{}", parts.join(" | "))
         }
@@ -186,7 +201,10 @@ fn render_for_style(
                 parts.push(format_tool_summary_discord(&summary.tool_groups));
             }
             if let Some(hits) = summary.memory_hits {
-                parts.push(format!("memory `hits={hits}`"));
+                parts.push(format!(
+                    "recall `short={} long={}`",
+                    hits.short_hits, hits.long_hits
+                ));
             }
             let subtext = format!("-# {}", escape_discord_subtext(&parts.join(" • ")));
             format!("{reply}\n{subtext}")
@@ -214,6 +232,7 @@ mod tests {
             tool_calls_enabled,
             false,
             false,
+            0,
             0,
             GatewayChannelKind::Discord,
         )
@@ -391,10 +410,26 @@ mod tests {
             false,
             true,
             true,
+            0,
             2,
             GatewayChannelKind::Discord,
         );
-        assert!(rendered.contains("-# memory `hits=2`"));
+        assert!(rendered.contains("-# recall `short=0 long=2`"));
+    }
+
+    #[test]
+    fn memory_recall_transparency_renders_short_and_long_hits() {
+        let rendered = render_tool_call_transparency(
+            "base reply",
+            &[],
+            false,
+            true,
+            true,
+            1,
+            2,
+            GatewayChannelKind::Discord,
+        );
+        assert!(rendered.contains("-# recall `short=1 long=2`"));
     }
 
     #[test]
@@ -405,6 +440,7 @@ mod tests {
             false,
             true,
             false,
+            0,
             0,
             GatewayChannelKind::Discord,
         );
@@ -429,9 +465,10 @@ mod tests {
             true,
             true,
             1,
+            1,
             GatewayChannelKind::Discord,
         );
-        assert!(rendered.contains("-# tools [clock `ok×1`] • memory `hits=1`"));
+        assert!(rendered.contains("-# tools [clock `ok×1`] • recall `short=1 long=1`"));
         assert!(!rendered.contains("\n-# memory"));
     }
 }


### PR DESCRIPTION
## Summary
- rename the recalled prompt section to neutral memory wording
- split recall transparency into short-term and long-term counts and label it as recall
- update the README to describe combined recall from long-term facts and older same-session short-term memory

## Testing
- cargo test -q
